### PR TITLE
Fix a problem with generation of github_j.ml.

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -531,7 +531,7 @@ module Atdgen = struct
 
   let rules () =
     rule "%.atd -> %_j.ml{i}" ~prods:["%_j.ml";"%_j.mli"] ~dep:"%.atd"
-     (run_atdgen "%_j.ml" (fun tags -> tags++"generate"++"json"));
+     (run_atdgen "%_j.ml" (fun tags -> tags++"generate"++"std_json"));
     rule "%.atd -> %_t.ml{i}" ~prods:["%_t.ml";"%_t.mli"] ~dep:"%.atd"
      (run_atdgen "%_t.ml" (fun tags -> tags++"generate"++"typedef"));
     rule "%.atd -> %_b.ml{i}" ~prods:["%_b.ml";"%_b.mli"] ~dep:"%.atd"
@@ -539,7 +539,7 @@ module Atdgen = struct
     rule "%.atd -> %_v.ml{i}" ~prods:["%_v.ml";"%_v.mli"] ~dep:"%.atd"
      (run_atdgen "%_v.ml" (fun tags -> tags++"generate"++"validator"));
     flag ["atdgen"; "generate"; "json"] & S[A"-j"];
-    flag ["atdgen"; "generate"; "std_json"] & S[A"-j-std"];
+    flag ["atdgen"; "generate"; "std_json"] & S[A"-j"; A"-j-std"];
     flag ["atdgen"; "generate"; "typedef"] & S[A"-t"];
     flag ["atdgen"; "generate"; "biniou"] & S[A"-b"];
     flag ["atdgen"; "generate"; "validator"] & S[A"-v"];


### PR DESCRIPTION
I met a problem while compiling github with a recent version of atdgen. 
I had to add -j-std to serialize correctly in json.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
