### PR TITLE
exposes `log_active` as a boolean reference

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -18,11 +18,12 @@
 
 let user_agent = "ocaml-github" (* TODO: add version from build system *)
 
-let log_active = try Unix.getenv "GITHUB_DEBUG" <> "0" with _ -> false
+let log_active =
+  ref (try Unix.getenv "GITHUB_DEBUG" <> "0" with _ -> false)
 
 let log fmt =
   Printf.ksprintf (fun s ->
-    match log_active with
+    match !log_active with
     | false -> ()
     | true  -> prerr_endline (">>> GitHub: " ^ s)) fmt
 

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -370,3 +370,8 @@ module Tag : sig
     user:string -> repo:string ->
     unit -> (string * string) list Monad.t
 end
+
+(** [log_active] activates debug messages
+
+    set by default when the environment variable GITHUB_DEBUG is set to 1 *)
+val log_active : bool ref


### PR DESCRIPTION
This is helpful when playing from a toplevel: in case of failure, I
would like to be able to activate logging without breaking out of the
toplevel.
