### PR TITLE
Error messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,7 +49,9 @@
 * Monad.map, Monad.(>|=), and Monad.embed : 'a Lwt.t -> 'a Monad.t added
 * Add Stream module and API.get_stream function for paginated responses (#46)
 * git-jar now supports 2FA (#38)
-* Github.{auth_continuation,handler} type added
+* Github.auth_continuation type added
+* Github.handler type added
+* Github.Message exception added and raised when GitHub returns an API error
 * Event submodule added with a variety of event sources
 * A new jar command, git-list-events, has been added to print events for a repo
 * A new test binary, parse_events, has been added which downloads and

--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,7 @@
 * Github.auth_continuation type added
 * Github.handler type added
 * Github.Message exception added and raised when GitHub returns an API error
+* API.string_of_message added for human consumption of structured errors
 * Event submodule added with a variety of event sources
 * A new jar command, git-list-events, has been added to print events for a repo
 * A new test binary, parse_events, has been added which downloads and

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -500,7 +500,7 @@ module Make(CL : Cohttp_lwt.Client) = struct
         end
       | [] ->
         match CL.Response.status envelope with
-        | `Unprocessable_entity | `Gone ->
+        | `Unprocessable_entity | `Gone | `Unauthorized ->
           CLB.to_string body
           >>= fun message ->
           let message = Github_j.message_of_string message in

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -17,6 +17,8 @@
 
 (** GitHub APIv3 client library *)
 module type Github = sig
+  exception Message of Github_t.message
+
   (** All API requests are bound through this monad. The [run] function
       will unpack an API response into an Lwt thread that will hold the
       ultimate response. *)
@@ -165,6 +167,8 @@ module type Github = sig
     val set_user_agent : string -> unit Monad.t
 
     val set_token : Token.t -> unit Monad.t
+
+    val string_of_message : Github_t.message -> string
   end
 
   (** Useful URI generation functions, normally for displaying on a web-page.


### PR DESCRIPTION
Instead of failing with `Failure` on GitHub API errors, we fail with `Message` now.