### PR TITLE
Refactor 2fa support to remove continuation and allow re-use of otp

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
 1.0.0 (trunk):
 * Changes marked with ! are type changes (not including field additions)
 * ! API.{get,post,delete,patch,put} now take optional fail_handlers
-* ! Token.{create,get_all,get,delete} now return _ auth_continuation Monad.t
+* ! Token.{create,get_all,get,delete} now return _ authorization Monad.t
+* ! Token.{create,get_all,get,delete} now have additional ?otp:string argument
 * ! User.current_info ~token argument was made optional ?token
 * ! User.info ~login argument was renamed to User.info ~user
 * ! User.repositories now accepts optional ?token and does not accept ?page
@@ -49,7 +50,7 @@
 * Monad.map, Monad.(>|=), and Monad.embed : 'a Lwt.t -> 'a Monad.t added
 * Add Stream module and API.get_stream function for paginated responses (#46)
 * git-jar now supports 2FA (#38)
-* Github.auth_continuation type added
+* Github.authorization type added
 * Github.handler type added
 * Github.Message exception added and raised when GitHub returns an API error
 * API.string_of_message added for human consumption of structured errors

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -61,11 +61,10 @@ module type Github = sig
   end
 
   (** Some results may require 2-factor authentication. [Result]
-      values do not. [Auth] values contain the mode of 2FA and the
-      continuation to be executed when the code is known. *)
-  type 'a auth_continuation =
+      values do not. [Two_factor] values contain the mode of 2FA. *)
+  type 'a authorization =
     | Result of 'a
-    | Auth of string * (string -> 'a auth_continuation Monad.t)
+    | Two_factor of string
 
   type +'a parse = string -> 'a Lwt.t
   type 'a handler =
@@ -88,15 +87,16 @@ module type Github = sig
 
     val create : ?scopes:Github_t.scope list -> ?note:string ->
       ?note_url:string -> ?client_id:string -> ?client_secret:string ->
+      ?otp:string ->
       user:string -> pass:string -> unit ->
-      Github_t.auth auth_continuation Monad.t
+      Github_t.auth authorization Monad.t
 
-    val get_all : user:string -> pass:string -> unit ->
-      Github_t.auths auth_continuation Monad.t
-    val get : user:string -> pass:string -> id:int -> unit ->
-      Github_t.auth auth_continuation Monad.t
-    val delete : user:string -> pass:string -> id:int -> unit ->
-      unit auth_continuation Monad.t
+    val get_all : ?otp:string -> user:string -> pass:string -> unit ->
+      Github_t.auths authorization Monad.t
+    val get : ?otp:string -> user:string -> pass:string -> id:int -> unit ->
+      Github_t.auth authorization Monad.t
+    val delete : ?otp:string -> user:string -> pass:string -> id:int -> unit ->
+      unit authorization Monad.t
 
     val of_auth : Github_t.auth -> t
     val of_string : string -> t

--- a/lib_test/get_token.ml
+++ b/lib_test/get_token.ml
@@ -9,7 +9,7 @@ let t = Github.(
     let token = Token.of_auth auth in
     prerr_endline (Token.to_string token);
     return ()
-  | Auth (_,_) -> fail (Failure "get_token doesn't support 2fa, yet")
+  | Two_factor _ -> fail (Failure "get_token doesn't support 2fa, yet")
 )
 
 ;;


### PR DESCRIPTION
This makes conditional creation of tokens nicer (e.g. in opam-publish).