### PR TITLE
Rate limit support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,10 @@
 * Add API.code_handler to make creating fail_handlers easier
 * Github.Message exception added and raised when GitHub returns an API error
 * Add API.string_of_message for human consumption of structured errors
+* Add API.get_rate to retrieve possibly cached rate-limit information
+* Add API.get_rate_limit to retrieve the possibly cached query quota
+* Add API.get_rate_remaining to retrieve the possibly cached query quota remaining
+* Add API.get_rate_reset to retrieve the possibly cached quota expiry
 * Add Repo.fork to create fork of a repository to the present user or given org
 * Add Repo.forks to list the forks of a given repository
 * Event submodule added with a variety of event sources

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 1.0.0 (trunk):
 * Changes marked with ! are type changes (not including field additions)
 * ! API.{get,post,delete,patch,put} now take optional fail_handlers
+* ! API.{get,post,delete,patch,put} now take optional rate classification
 * ! Token.{create,get_all,get,delete} now return _ authorization Monad.t
 * ! Token.{create,get_all,get,delete} now have additional ?otp:string argument
 * ! Token.create now has additional ?fingerprint:string argument
@@ -58,6 +59,7 @@
 * Fix git-jar token file permissions security vulnerability
 * git-jar now supports 2FA (#38)
 * Github.authorization type added
+* Github.rate type added for classifying requests into rate limiting regime
 * Github.handler type added
 * Add API.code_handler to make creating fail_handlers easier
 * Github.Message exception added and raised when GitHub returns an API error

--- a/CHANGES
+++ b/CHANGES
@@ -68,9 +68,10 @@
 * Add API.get_rate_limit to retrieve the possibly cached query quota
 * Add API.get_rate_remaining to retrieve the possibly cached query quota remaining
 * Add API.get_rate_reset to retrieve the possibly cached quota expiry
+* Add Rate_limit module to perform explicit rate limit requests
 * Add Repo.fork to create fork of a repository to the present user or given org
 * Add Repo.forks to list the forks of a given repository
-* Event submodule added with a variety of event sources
+* Add Event module with a variety of event sources
 * A new jar command, git-list-events, has been added to print events for a repo
 * A new test binary, parse_events, has been added which downloads and
   parses archive event data

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -9,6 +9,21 @@ type message = {
   ~errors <ocaml default="[]">: error list;
 } <ocaml field_prefix="message_">
 
+type rate = {
+  limit: int;
+  remaining: int;
+  reset: int;
+} <ocaml field_prefix="rate_">
+
+type rate_resources = {
+  core: rate;
+  search: rate;
+} <ocaml field_prefix="rate_resources_">
+
+type rate_limit = {
+  resources: rate_resources;
+} <ocaml field_prefix="rate_limit_">
+
 type scope = [
   | User <json name="user">
   | UserEmail <json name="user:email">

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -179,7 +179,7 @@ module type Github = sig
 
     val set_token : Token.t -> unit Monad.t
 
-    val get_rate : ?token:Token.t -> unit -> Github_t.rate Monad.t
+    val get_rate : ?rate:rate -> ?token:Token.t -> unit -> Github_t.rate Monad.t
 
     val get_rate_limit : ?token:Token.t -> unit -> int Monad.t
 
@@ -205,6 +205,12 @@ module type Github = sig
     val repo_pulls : user:string -> repo:string -> Uri.t
     val repo_milestones : user:string -> repo:string -> Uri.t
     val milestone : user:string -> repo:string -> num:int -> Uri.t
+  end
+
+  module Rate_limit : sig
+    val all : ?token:Token.t -> unit -> Github_t.rate_resources Monad.t
+    val for_core : ?token:Token.t -> unit -> Github_t.rate Monad.t
+    val for_search : ?token:Token.t -> unit -> Github_t.rate Monad.t
   end
 
   module User : sig

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -61,6 +61,8 @@ module type Github = sig
     val of_list : 'a list -> 'a t
   end
 
+  type rate = Core | Search
+
   (** Some results may require 2-factor authentication. [Result]
       values do not. [Two_factor] values contain the mode of 2FA. *)
   type 'a authorization =
@@ -111,6 +113,7 @@ module type Github = sig
     val code_handler : expected_code:Cohttp.Code.status_code -> 'a -> 'a handler
 
     val get :
+      ?rate:rate ->
       ?fail_handlers:'a parse handler list ->
       ?expected_code:Cohttp.Code.status_code ->
       ?headers:Cohttp.Header.t -> 
@@ -120,6 +123,7 @@ module type Github = sig
       'a parse -> 'a Monad.t
 
     val get_stream :
+      ?rate:rate ->
       ?fail_handlers:'a Stream.parse handler list ->
       ?expected_code:Cohttp.Code.status_code ->
       ?headers:Cohttp.Header.t ->
@@ -129,6 +133,7 @@ module type Github = sig
       'a Stream.parse -> 'a Stream.t
 
     val post :
+      ?rate:rate ->
       ?fail_handlers:'a parse handler list ->
       expected_code:Cohttp.Code.status_code ->
       ?headers:Cohttp.Header.t ->
@@ -139,6 +144,7 @@ module type Github = sig
       (string -> 'a Lwt.t) -> 'a Monad.t
 
     val delete :
+      ?rate:rate ->
       ?fail_handlers:'a parse handler list ->
       ?expected_code:Cohttp.Code.status_code ->
       ?headers:Cohttp.Header.t -> 
@@ -148,6 +154,7 @@ module type Github = sig
       (string -> 'a Lwt.t) -> 'a Monad.t
 
     val patch :
+      ?rate:rate ->
       ?fail_handlers:'a parse handler list ->
       expected_code:Cohttp.Code.status_code ->
       ?headers:Cohttp.Header.t ->
@@ -158,6 +165,7 @@ module type Github = sig
       (string -> 'a Lwt.t) -> 'a Monad.t
 
     val put :
+      ?rate:rate ->
       ?fail_handlers:'a parse handler list ->
       expected_code:Cohttp.Code.status_code ->
       ?headers:Cohttp.Header.t ->

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -171,6 +171,14 @@ module type Github = sig
 
     val set_token : Token.t -> unit Monad.t
 
+    val get_rate : ?token:Token.t -> unit -> Github_t.rate Monad.t
+
+    val get_rate_limit : ?token:Token.t -> unit -> int Monad.t
+
+    val get_rate_remaining : ?token:Token.t -> unit -> int Monad.t
+
+    val get_rate_reset : ?token:Token.t -> unit -> int Monad.t
+
     val string_of_message : Github_t.message -> string
   end
 


### PR DESCRIPTION
A bit tangly but now we harvest the rate limit info that comes back from every request. Unfortunately, GitHub has multiple quota regimes depending on the endpoint you are using. Right now, only `core` and `search` exist but it could get more complicated in the future. The generic query interface expanded a bit to accommodate these rate regimes and we gained a new top-level tag type. There is also a global, shared mutable hash table to keep track of the rate limiting info because it is per-token from GitHub's perspective. If you wish to bypass this cache, the `Rate_limit` module has been added to force (and cache) a free rate limit query.

I'm not super happy with this design but it seems to make some amount of sense and, importantly, it works. There are various concurrency edge cases that I've not attempted to handle but, in applications with reasonable request throughput, the rate limiting info will not be very much out of date at any time.

No provision for cache expiry has been made.

Review welcome.