### PR TITLE
Readme rewrite with API support coverage

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -86,6 +86,7 @@
 * ! branch_user is now optional
 * ! user_info_ty field removed in favor of specific user and organization types
 * ! user_type type has been removed
+* ! org_gravatar_id field and all derived fields (e.g. user_gravatar_id) removed
 * ! team_info_permission is now a variant type instead of a string
 * ! team_info_organization is now an org rather than a user
 * ! event_org field is now an org option rather than a user

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Your Github application can how use it via the `Github_cookie_jar` module:
 
 The [Releases](https://developer.github.com/v3/repos/releases/) API in
 GitHub cannot itself be synched via Git, so this command-line tool lets
-you specify a src user/repo and destination user/repo pair, and copies
+you specify a source user/repo and destination user/repo pair, and copies
 all the releases from one to the other.
 
 The `git-sync-releases` binary can copy all the releases from one
@@ -170,7 +170,7 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Edit an issue comment](https://developer.github.com/v3/issues/comments/#edit-a-comment)
  * [Delete an issue comment](https://developer.github.com/v3/issues/comments/#delete-a-comment)
  * [Issue events](https://developer.github.com/v3/issues/events/#list-events-for-an-issue)
- * [All issue event types](https://developer.github.com/v3/issues/events/)
+ * [Several issue event type](https://developer.github.com/v3/issues/events/)
  * [Labels](https://developer.github.com/v3/issues/labels/)
 
 ### [Miscellaneous](https://developer.github.com/v3/misc/)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
-GitHub APIv3 OCaml Library
-==========================
+# GitHub APIv3 OCaml Library
 
-This library provides an OCaml interface to the Github JSON API.  It is not
-yet complete, but look in `lib/github.atd` for the specification that has
-been implemented so far.  The full API details can be found at:
-<http://developer.github.com/v3/>
+This library provides an OCaml interface to the [GitHub
+APIv3](https://developer.github.com/v3/) (JSON).
 
-There are several tests in `lib_test` for small bits of functionality, and for
-the authenticated ones you will need to edit `lib_test/config.ml` with suitable
-auth information.  Use the `get_token` test to obtain an oAuth token for the
-config file.
+It is [not yet complete](#api-support-coverage) but
+[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib/github.atd)
+contains the data types that have been bound so far.
+
+There are several tests and examples in
+[lib_test](https://github.com/mirage/ocaml-github/tree/master/lib_test)
+for small bits of
+functionality. [jar](https://github.com/mirage/ocaml-github/tree/master/jar)
+contains utility programs that use the [git jar](#git-jar) facility for
+stored tokens.
+
+## Debugging
 
 Two environment variables will cause more debugging to be output:
 
@@ -20,19 +25,19 @@ If using the bindings from the toplevel, you can also set `Github.log_active`
 to `true` to get the same effect as setting the `GITHUB_DEBUG` environment
 variable.
 
-Cookie jar
-==========
+## `git jar`
 
-Applications that use this library will need to save authorization tokens
-locally, and the `Github_cookie_jar` module in the `unix/` directory helps
-handle this more naturally.  It maps an authorization token onto a local
-application name, which can then query that token at runtime and use it in
-Github API calls.
+Applications that use this library will need to save authorization
+tokens locally, and the `Github_cookie_jar` module in
+[unix](https://github.com/mirage/ocaml-github/tree/master/unix) helps
+handle this more naturally.  It maps local application name to an
+authorization token so that the application can query the cookie jar at
+runtime and use the resulting token in Github API calls.
 
 The tokens are all stored in `$HOME/.github/jar/<name>`, where `<name>` is the
 local name of the application.
 
-A `git-jar` command is also installed to add, remove and list the contents
+A `git-jar` command will be installed to add, remove, and list the contents
 of this cookie jar.
 
 ```console
@@ -76,8 +81,7 @@ Your Github application can how use it via the `Github_cookie_jar` module:
     Github_t.auth_note_url = None }
 ```
 
-Manipulate GitHub releases
-==========================
+## Manipulate GitHub releases
 
 The [Releases](https://developer.github.com/v3/repos/releases/) API in
 GitHub cannot itself be synched via Git, so this command-line tool lets
@@ -98,3 +102,201 @@ will do this for you.
 ```
 $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
 ```
+
+## API support coverage
+
+### [Media Types](https://developer.github.com/v3/media/)
+
+*Supported*: application/vnd.github.v3+json
+
+*Not yet supported*: Other media types
+
+### [OAuth](https://developer.github.com/v3/oauth/)
+*Supported*:
+
+ * Web and non-Web flows with two-factor authentication
+ * Basic Authorizations API
+
+*Not yet supported*:
+
+ * get-or-create, update, check, reset, revoke
+ * fingerprint endpoints
+
+### [Activity](https://developer.github.com/v3/activity/)
+*Supported*:
+
+ * All [Events](https://developer.github.com/v3/activity/events/) endpoints
+ * Event types: commit comment, create, delete, deployment, deployment status,
+   download, follow, fork, fork apply, gist, gollum, issue comment,
+   issues, member, page build, public, pull request, pull request review
+   comment, push, release, status, team add, watch
+
+*Not yet supported*:
+
+ * Event types: membership, repository
+ * [Feeds](https://developer.github.com/v3/activity/feeds/)
+ * [Notifications](https://developer.github.com/v3/activity/notifications/)
+ * [Starring](https://developer.github.com/v3/activity/starring/)
+ * [Watching](https://developer.github.com/v3/activity/watching/)
+
+### [Gists](https://developer.github.com/v3/gists/)
+*Supported*:
+
+ * All endpoints
+
+*Not yet supported*:
+
+ * Special media types
+ * Truncation helpers
+
+### [Git Data](https://developer.github.com/v3/git/)
+
+*Not yet supported*: everything (see
+ [#40](https://github.com/mirage/ocaml-github/issues/40))
+
+### [Issues](https://developer.github.com/v3/issues/)
+*Supported*:
+
+ * All basic endpoints
+ * Basic comments endpoints
+ * [Milestones](https://developer.github.com/v3/issues/milestones/)
+
+*Not yet supported*:
+
+ * Custom media types
+ * [Assignees](https://developer.github.com/v3/issues/assignees/)
+ * [Repository issue comments](https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository)
+ * [Get a single issue comment](https://developer.github.com/v3/issues/comments/#get-a-single-comment)
+ * [Edit an issue comment](https://developer.github.com/v3/issues/comments/#edit-a-comment)
+ * [Delete an issue comment](https://developer.github.com/v3/issues/comments/#delete-a-comment)
+ * [Issue events](https://developer.github.com/v3/issues/events/#list-events-for-an-issue)
+ * [All issue event types](https://developer.github.com/v3/issues/events/)
+ * [Labels](https://developer.github.com/v3/issues/labels/)
+
+### [Miscellaneous](https://developer.github.com/v3/misc/)
+*Supported*:
+
+ * [Rate limit](https://developer.github.com/v3/rate_limit/)
+
+*Not yet supported*:
+
+ * [Emojis](https://developer.github.com/v3/emojis)
+ * [Gitignore](https://developer.github.com/v3/gitignore)
+ * [Markdown](https://developer.github.com/v3/markdown)
+ * [Meta](https://developer.github.com/v3/meta)
+ * [Licenses](https://developer.github.com/v3/licenses)
+
+### [Organizations](https://developer.github.com/v3/orgs/)
+*Supported*:
+
+ * [List teams](https://developer.github.com/v3/orgs/teams/#list-teams)
+ * [Get team](https://developer.github.com/v3/orgs/teams/#get-team)
+ * [List team repos](https://developer.github.com/v3/orgs/teams/#list-team-repos)
+
+*Not yet supported*: everything else
+
+### [Pull Requests](https://developer.github.com/v3/pulls/)
+*Supported*:
+
+ * All endpoints
+
+*Not yet supported*:
+
+ * Link relations
+ * Custom media types
+
+### [Repositories](https://developer.github.com/v3/repos/)
+*Supported*:
+
+ * [List user
+   repositories](https://developer.github.com/v3/repos/#list-user-repositories)
+ * [Get](https://developer.github.com/v3/repos/#get)
+ * [List tags](https://developer.github.com/v3/repos/#list-tags)
+ * [List branches](https://developer.github.com/v3/repos/#list-branches)
+ * [Get a single
+   commit](https://developer.github.com/v3/repos/commits/#get-a-single-commit)
+ * [Deploy keys](https://developer.github.com/v3/repos/keys/)
+ * [Forks](https://developer.github.com/v3/repos/forks/)
+ * Most [Releases](https://developer.github.com/v3/repos/releases/) endpoints
+ * [Create a
+   status](https://developer.github.com/v3/repos/statuses/#create-a-status)
+ * [List statuses for a specific
+   ref](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref)
+ * Most [Webhooks](https://developer.github.com/v3/repos/hooks/)
+   endpoints
+
+*Not yet supported*:
+
+ * [List your
+   repositories](https://developer.github.com/v3/repos/#list-your-repositories)
+ * [List organization
+   repositories](https://developer.github.com/v3/repos/#list-organization-repositories)
+ * [List all public
+   repositories](https://developer.github.com/v3/repos/#list-all-public-repositories)
+ * [Create](https://developer.github.com/v3/repos/#create)
+ * [Edit](https://developer.github.com/v3/repos/#edit)
+ * [List contributors](https://developer.github.com/v3/repos/#list-contributors)
+ * [List
+   languages](https://developer.github.com/v3/repos/#list-languages)
+ * [List teams](https://developer.github.com/v3/repos/#list-teams)
+ * [Get branch](https://developer.github.com/v3/repos/#get-branch)
+ * [Delete repository](https://developer.github.com/v3/repos/#delete-a-repository)
+ * [Collaborators](https://developer.github.com/v3/repos/collaborators/)
+ * [Commit comments](https://developer.github.com/v3/repos/comments/)
+ * [List
+   commits](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository)
+ * [Compare two
+   commits](https://developer.github.com/v3/repos/commits/#compare-two-commits)
+ * [Contents](https://developer.github.com/v3/repos/contents/)
+ * [Deployments](https://developer.github.com/v3/repos/deployments/)
+ * [Merging](https://developer.github.com/v3/repos/merging/)
+ * [Pages](https://developer.github.com/v3/repos/pages/)
+ * [Get the latest
+   release](https://developer.github.com/v3/repos/releases/#get-the-latest-release)
+ * [List assets for a
+   release](https://developer.github.com/v3/repos/releases/#list-assets-for-a-release)
+ * [Get a single release
+   asset](https://developer.github.com/v3/repos/releases/#get-a-single-release-asset)
+ * [Edit a release
+   asset](https://developer.github.com/v3/repos/releases/#edit-a-release-asset)
+ * [Delete a release
+   asset](https://developer.github.com/v3/repos/releases/#delete-a-release-asset)
+ * [Statistics](https://developer.github.com/v3/repos/statistics/)
+ * [Get the combined status for a specific
+   ref](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref)
+ * [Ping a
+   hook](https://developer.github.com/v3/repos/hooks/#ping-a-hook)
+ * [PubSubHubbub](https://developer.github.com/v3/repos/hooks/#pubsubhubbub)
+ * [Receiving Webhooks
+   helpers](https://developer.github.com/v3/repos/hooks/#receiving-webhooks)
+
+### [Search](https://developer.github.com/v3/search/)
+*Supported*:
+
+ * [Search
+   repositories](https://developer.github.com/v3/search/#search-repositories)
+
+*Not yet supported*:
+
+ * [Search code](https://developer.github.com/v3/search/#search-code)
+ * [Search issues](https://developer.github.com/v3/search/#search-issues)
+ * [Search users](https://developer.github.com/v3/search/#search-users)
+ * [Text match media
+    type](https://developer.github.com/v3/search/#text-match-metadata)
+
+### [Users](https://developer.github.com/v3/users/)
+*Supported*:
+
+ * [Get a single
+   user](https://developer.github.com/v3/users/#get-a-single-user)
+ * [Get the authenticated
+   user](https://developer.github.com/v3/users/#get-the-authenticated-user)
+
+*Not yet supported*:
+
+ * [Update the authenticated
+   user](https://developer.github.com/v3/users/#update-the-authenticated-user)
+ * [Get all users](https://developer.github.com/v3/users/#get-all-users)
+
+### [Enterprise](https://developer.github.com/v3/enterprise/)
+*Not yet supported*: everything

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -102,7 +102,6 @@ type org = {
   id: int;
   url: string;
   ?avatar_url: string option;
-  ?gravatar_id: string option;
 } <ocaml field_prefix="org_">
 
 type user = {

--- a/opam
+++ b/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 name: "github"
 version: "1.0.0"
-maintainer: "anil@recoil.org"
+maintainer: "sheets@alum.mit.edu"
 authors: [ "Anil Madhavapeddy" "David Sheets" "Andy Ray" "Jeff Hammerbacher" ]
 homepage: "https://github.com/mirage/ocaml-github"
 bug-reports: "https://github.com/mirage/ocaml-github/issues"


### PR DESCRIPTION
This rewrites the README with a comprehensive listing of the parts of the GitHub v3 API that are bound and are still yet to be bound.

I also removed the `gravatar_id` field as it has been deprecated in favor of `avatar_url`.