### PR TITLE
Register an exception printer for Github.Messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
 * Add stats_contributors type (#114 by @sevenEng)
 * Add contribution_week type
 * Fix Repo.get_tags_and_times exception when repository has no tags (#113)
+* Register automatically a Message exception printer (#116)
 
 1.0.0 (2015-06-01):
 * Changes marked with ! are type changes (not including field additions)


### PR DESCRIPTION
When exceptions are uncaught, a useful message will be printed instead of an opaque serialization of a polymorphic variant and a message structure.