### PR TITLE
Add schema for pushEvent webhook delivery

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -615,9 +615,14 @@ type push_event_commit = {
 } <ocaml field_prefix="push_event_commit_">
 
 type push_event = {
-  head: string;
+  ?head: string option;
   ref: string;
   size: int;
+  before: string;
+  ?after: string option;
+  ?created: bool option;
+  ?deleted: bool option;
+  ?forced: bool option;
   commits: push_event_commit list;
 } <ocaml field_prefix="push_event_">
 


### PR DESCRIPTION
The GitHub API is not consistent between the events API and the webhook
deliveries. See https://developer.github.com/v3/activity/events/types/#pushevent

> The Events API PushEvent payload is described in the table
  below. The example payload below that is from a webhook delivery and
  will differ from the Events API PushEvent payload

I haven't found any description of this difference, so I had to inspect webhook
delivery payloads ...