### PR TITLE
Support retrieving the public organizations for a user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [List teams](https://developer.github.com/v3/orgs/teams/#list-teams)
  * [Get team](https://developer.github.com/v3/orgs/teams/#get-team)
  * [List team repos](https://developer.github.com/v3/orgs/teams/#list-team-repos)
+ * [List (public) user organizations](https://developer.github.com/v3/orgs/#list-user-organizations)
 
 *Not yet supported*: everything else
 

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -104,6 +104,8 @@ type org = {
   ?avatar_url: string option;
 } <ocaml field_prefix="org_">
 
+type orgs = org list
+
 type user = {
   inherit org
 } <ocaml field_prefix="user_">

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -346,6 +346,9 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
 
     let team_repos ~id =
       Uri.of_string (Printf.sprintf "%s/teams/%Ld/repos" api id)
+
+    let user_orgs ~user =
+      Uri.of_string (Printf.sprintf "%s/users/%s/orgs" api user)
   end
 
   module C = Cohttp
@@ -1025,6 +1028,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let teams ?token ~org () =
       let uri = URI.org_teams ~org in
       API.get_stream ?token ~uri (fun b -> return (teams_of_string b))
+
+    let user_orgs ?token ~user () =
+      let uri = URI.user_orgs ~user in
+      API.get_stream ?token ~uri (fun b -> return (orgs_of_string b))
   end
 
   module Team = struct

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -584,6 +584,13 @@ module type Github = sig
       unit -> Github_t.team Stream.t
     (** [teams ~org ()] is a stream of teams belonging to the
         organization [org]. *)
+
+    val user_orgs :
+      ?token:Token.t ->
+      user:string ->
+      unit -> Github_t.org Stream.t
+    (** [user_organizations ~user ()] is a stream of the organizations
+         to which the user [user] belongs. *)
   end
 
   (** The [Team] module contains functionality relating to GitHub's


### PR DESCRIPTION
[API call here: https://developer.github.com/v3/orgs/#list-user-organizations]

Example:

```ocaml
# Lwt_unix.run @@ Monad.run @@ Stream.to_list @@ Organization.user_orgs ~user:"amirmc" ();;
- : Github_t.org list =
[{Github_t.org_login = "mirage"; org_id = 131943L;
  org_url = "https://api.github.com/orgs/mirage";
  org_avatar_url = Some "https://avatars.githubusercontent.com/u/131943?v=3"};
 {Github_t.org_login = "horizon-institute"; org_id = 167906L;
  org_url = "https://api.github.com/orgs/horizon-institute";
  org_avatar_url = Some "https://avatars.githubusercontent.com/u/167906?v=3"};
 {Github_t.org_login = "signposts"; org_id = 1529467L;
  org_url = "https://api.github.com/orgs/signposts";
  org_avatar_url = Some "https://avatars.githubusercontent.com/u/1529467?v=3"};
 {Github_t.org_login = "nymote"; org_id = 1618865L;
  org_url = "https://api.github.com/orgs/nymote";
  org_avatar_url = Some "https://avatars.githubusercontent.com/u/1618865?v=3"};
 {Github_t.org_login = "ocaml"; org_id = 1841483L;
  org_url = "https://api.github.com/orgs/ocaml";
  org_avatar_url = Some "https://avatars.githubusercontent.com/u/1841483?v=3"};
 {Github_t.org_login = "ocamllabs"; org_id = 2475115L;
  org_url = "https://api.github.com/orgs/ocamllabs";
  org_avatar_url = Some "https://avatars.githubusercontent.com/u/2475115?v=3"};
 {Github_t.org_login = "ocaml-attic"; org_id = 6136894L;
  org_url = "https://api.github.com/orgs/ocaml-attic";
  org_avatar_url = Some "https://avatars.githubusercontent.com/u/6136894?v=3"}]
```