### PR TITLE
Fix the Event.for_repo_issues call.

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -511,6 +511,35 @@ type gollum_event = {
   pages: wiki_page list;
 } <ocaml field_prefix="gollum_event_">
 
+type repo_issues_action = [
+  | Closed <json name="closed">
+  | Reopened <json name="reopened">
+  | Subscribed <json name="subscribed">
+  | Merged <json name="merged">
+  | Referenced <json name="referenced">
+  | Mentioned <json name="mentioned">
+  | Assigned <json name="assigned">
+  | Unassigned <json name="unassigned">
+  | Labeled <json name="labeled">
+  | Unlabeled <json name="unlabeled">
+  | Milestoned <json name="milestoned">
+  | Demilestoned <json name="demilestoned">
+  | Renamed <json name="renamed">
+  | Locked <json name="locked">
+  | Unlocked <json name="unlocked">
+  | Head_ref_deleted <json name="head_ref_deleted">
+  | Head_ref_restored <json name="head_ref_restored">
+]
+
+type repo_issues_event = {
+  event: repo_issues_action;
+  issue: issue;
+  ?assignee: user_info option;
+  ?label: label option;
+} <ocaml field_prefix="issues_event_">
+
+type repo_issues_events = repo_issues_event list
+
 type issue_comment_action = [
   | Created <json name="created">
 ]

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -531,14 +531,19 @@ type repo_issues_action = [
   | Head_ref_restored <json name="head_ref_restored">
 ]
 
-type repo_issues_event = {
+type repo_issue_event = {
   event: repo_issues_action;
-  issue: issue;
   ?assignee: user_info option;
   ?label: label option;
 } <ocaml field_prefix="issues_event_">
 
+type repo_issues_event = {
+  issue: issue;
+  inherit repo_issue_event
+} <ocaml field_prefix="issues_event_">
+
 type repo_issues_events = repo_issues_event list
+type repo_issue_events = repo_issue_event list
 
 type issue_comment_action = [
   | Created <json name="created">

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -285,7 +285,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let repo_events ~user ~repo =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/events" api user repo)
 
-    let repo_issue_events ~user ~repo =
+    let repo_issues_events ~user ~repo =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/events"
                        api user repo)
 
@@ -1532,8 +1532,8 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       API.get_stream ?token ~uri (fun b -> return (events_of_string b))
 
     let for_repo_issues ?token ~user ~repo () =
-      let uri = URI.repo_issue_events ~user ~repo in
-      API.get_stream ?token ~uri (fun b -> return (events_of_string b))
+      let uri = URI.repo_issues_events ~user ~repo in
+      API.get_stream ?token ~uri (fun b -> return (repo_issues_events_of_string b))
 
     let public_events () =
       let uri = URI.public_events in

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -289,6 +289,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/events"
                        api user repo)
 
+    let repo_issue_events ~user ~repo ~num =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/%d/events"
+                       api user repo num)
+
     let public_events = Uri.of_string (Printf.sprintf "%s/events" api)
 
     let network_events ~user ~repo =
@@ -1534,6 +1538,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let for_repo_issues ?token ~user ~repo () =
       let uri = URI.repo_issues_events ~user ~repo in
       API.get_stream ?token ~uri (fun b -> return (repo_issues_events_of_string b))
+
+    let for_repo_issue ?token ~user ~repo ~num () =
+      let uri = URI.repo_issue_events ~user ~repo ~num in
+      API.get_stream ?token ~uri (fun b -> return (repo_issue_events_of_string b))
 
     let public_events () =
       let uri = URI.public_events in

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -624,7 +624,7 @@ module type Github = sig
     val for_repo_issues :
       ?token:Token.t ->
       user:string ->
-      repo:string -> unit -> Github_t.event Stream.t
+      repo:string -> unit -> Github_t.repo_issues_event Stream.t
     (** [for_repo_issues ~user ~repo ()] is a stream of all issue
         events for [user]/[repo]. *)
 

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -628,6 +628,14 @@ module type Github = sig
     (** [for_repo_issues ~user ~repo ()] is a stream of all issue
         events for [user]/[repo]. *)
 
+    val for_repo_issue :
+      ?token:Token.t ->
+      user:string ->
+      repo:string -> 
+      num:int -> unit -> Github_t.repo_issue_event Stream.t
+    (** [for_repo_issue ~user ~repo ~num ()] is a stream of all issue
+        events for [user]/[repo]/issues/[num]. *)
+
     val public_events : unit -> Github_t.event Stream.t
     (** [public_events ()] is a stream of all public events on GitHub. *)
 


### PR DESCRIPTION
Before:
```ocaml
# Lwt_main.run (Github.Monad.run (Github.Stream.to_list (Github.Event.for_repo_issues ~user:"dsheets" ~repo:"ISO8601.ml"  ())));;
Bad response: Ag_oj_run.Error("Line 1:\nMissing record fields public, payload, repo, 0jic_type")
Exception:
Failure
 "Bad response: Ag_oj_run.Error(\"Line 1:\\nMissing record fields public, payload, repo, 0jic_type\")\n".
```
After:
```ocaml
# Lwt_main.run (Github.Monad.run (Github.Stream.to_list (Github.Event.for_repo_issues ~user:"dsheets" ~repo:"ISO8601.ml"  ())));;
- : Github_t.issues_event list =
[{Github_t.issues_event_event = `Referenced;
  issues_event_issue =
   {Github_t.issue_url =
     "https://api.github.com/repos/dsheets/ISO8601.ml/issues/1";
    issue_html_url = "https://github.com/dsheets/ISO8601.ml/pull/1";
    issue_number = 1; issue_state = `Closed;
    issue_title = "Add unix dependency to the META file.";
    issue_body =
[...]
```