### PR TITLE
push events seem to contain `tree_id` and `id` instead of `sha`

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -610,7 +610,8 @@ type push_event_author = {
 
 type push_event_commit = {
   url: string;
-  sha: string;
+  id: string;
+  tree_id: string;
   message: string;
   author: push_event_author;
   distinct: bool;


### PR DESCRIPTION
there is contradictory information about this in the github
docs.. https://developer.github.com/v3/activity/events/types/#pushevent

the text describes `sha` but the example has `id` with the sha
instead

closes #136