### PR TITLE
Make Repo.create's interface consistent with other functions

### DIFF
--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -1447,8 +1447,8 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
   module Repo = struct
     open Lwt
 
-    let create ?token ?organization new_repo () =
-      let body = string_of_new_repo new_repo in
+    let create ?token ?organization ~repo () =
+      let body = string_of_new_repo repo in
       let uri = match organization with
         | None -> URI.repos
         | Some org -> URI.org_repos org

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -691,7 +691,7 @@ module type Github = sig
     val create :
       ?token:Token.t ->
       ?organization:string ->
-      Github_t.new_repo ->
+      repo:Github_t.new_repo ->
       unit -> Github_t.repository Response.t Monad.t
     (** [create ?organization new_repo ()] is a new repository owned
         by the user or organizations if it's provided. *)


### PR DESCRIPTION
All arguments should be labeled.