### PR TITLE
update_issue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@
 * Add Repo.delete
 * Add Stream.fold
 * Add Issue.get
+* update_issue type added
+* Change Issue.update to accept update_issue rather than new_issue
+  This allows users to change issue state (open/close).
 
 1.1.0 (2016-06-20):
 * Add new_status_context and status_context fields (#88)

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -73,6 +73,11 @@ type auth = {
 
 type auths = auth list
 
+type state = [
+  | Open <json name="open">
+  | Closed <json name="closed">
+]
+
 type new_issue = {
   title: string;
   ?body: string option;
@@ -81,15 +86,15 @@ type new_issue = {
   ~labels: string list;
 } <ocaml field_prefix="new_issue_">
 
+type update_issue = {
+  ?state: state option;
+  inherit new_issue
+}
+
 type issue_sort = [
   | Created <json name="created">
   | Updated <json name="updated">
   | Comments <json name="comments">
-]
-
-type state = [
-  | Open <json name="open">
-  | Closed <json name="closed">
 ]
 
 type direction = [

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -87,9 +87,13 @@ type new_issue = {
 } <ocaml field_prefix="new_issue_">
 
 type update_issue = {
+  ?title: string option;
+  ?body: string option;
   ?state: state option;
-  inherit new_issue
-}
+  ?assignee: string option;
+  ?milestone: int option;
+  ?labels: string list option;
+} <ocaml field_prefix="update_issue_">
 
 type issue_sort = [
   | Created <json name="created">

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -1371,7 +1371,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       API.post ~body ?token ~uri ~expected_code:`Created (fun b -> return (issue_of_string b))
 
     let update ?token ~user ~repo ~num ~issue () =
-      let body = string_of_new_issue issue in
+      let body = string_of_update_issue issue in
       let uri = URI.repo_issue ~user ~repo ~num in
       API.patch ~body ?token ~uri ~expected_code:`OK
         (fun b -> return (issue_of_string b))

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -975,7 +975,7 @@ module type Github = sig
 
     val update :
       ?token:Token.t -> user:string -> repo:string ->
-      num:int -> issue:Github_t.new_issue ->
+      num:int -> issue:Github_t.update_issue ->
       unit -> Github_t.issue Response.t Monad.t
     (** [update ~user ~repo ~num ~issue ()] is the updated issue [num]
         in [user]/[repo] as described by [issue]. *)


### PR DESCRIPTION
`Issue.update` now takes `update_issue` instead of `new_issue`.

This allows the user to change the state (open/close) the issue.