### PR TITLE
Add Support for Labels

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 1.2.0 (dev):
+* Add Labels API support (#146 from @dave-tucker)
 * Make `tls` the default recommended dependency instead of OpenSSL
 * Add Repo.create
 * Add Repo.delete

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * All basic endpoints
  * Basic comments endpoints
  * [Milestones](https://developer.github.com/v3/issues/milestones/)
+ * [Labels](https://developer.github.com/v3/issues/labels/)
 
 *Not yet supported*:
 
@@ -179,7 +180,6 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Delete an issue comment](https://developer.github.com/v3/issues/comments/#delete-a-comment)
  * [Issue events](https://developer.github.com/v3/issues/events/#list-events-for-an-issue)
  * [Several issue event type](https://developer.github.com/v3/issues/events/)
- * [Labels](https://developer.github.com/v3/issues/labels/)
 
 ### [Miscellaneous](https://developer.github.com/v3/misc/)
 *Supported*:

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -187,6 +187,15 @@ type label = {
   color: string;
 } <ocaml field_prefix="label_">
 
+type labels = label list
+
+type new_label = {
+  name: string;
+  color: string;
+} <ocaml field_prefix="new_label_">
+
+type new_labels = string list
+
 type milestone_sort = [
   | Due_date <json name="due_date">
   | Completeness <json name="completeness">

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -231,6 +231,12 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let repo_search =
       Uri.of_string (Printf.sprintf "%s/search/repositories" api)
 
+    let repo_label ~user ~repo ~name =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/labels/%s" api user repo name)
+
+    let repo_labels ~user ~repo =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/labels" api user repo)
+
     let hook ~user ~repo ~id =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/hooks/%Ld" api user repo id)
 
@@ -260,12 +266,21 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
 
     let milestone ~user ~repo ~num =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/milestones/%d" api user repo num)
-
+    
+    let milestone_labels ~user ~repo ~num =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/milestones/%d/labels" api user repo num)
+ 
     let issue_comments ~user ~repo ~num =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/%d/comments" api user repo num)
 
     let issue_comment ~user ~repo ~num =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/comments/%d" api user repo num)
+
+    let issue_labels ~user ~repo ~num =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/%d/labels" api user repo num)
+
+    let issue_label ~user ~repo ~num ~name =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/%d/labels/%s" api user repo num name)
 
     let repo_releases ~user ~repo =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/releases" api user repo)
@@ -355,7 +370,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
 
     let user_orgs ~user =
       Uri.of_string (Printf.sprintf "%s/users/%s/orgs" api user)
-  end
+ end
 
   module C = Cohttp
   module CLB = Cohttp_lwt_body
@@ -1255,6 +1270,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       let uri = URI.milestone ~user ~repo ~num in
       let body = string_of_update_milestone milestone in
       API.patch ?token ~body ~uri ~expected_code:`OK (fun b -> return (milestone_of_string b))
+
+    let labels ?token ~user ~repo ~num () =
+      let uri = URI.milestone_labels ~user ~repo ~num in
+      API.get_stream ?token ~uri (fun b -> return (labels_of_string b))
   end
 
   module Release = struct
@@ -1385,9 +1404,57 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       let uri = URI.issue_comments ~user ~repo ~num in
       API.post ~body ?token ~uri ~expected_code:`Created (fun b -> return (issue_comment_of_string b))
 
+    let labels ?token ~user ~repo ~num () =
+      let uri = URI.issue_labels ~user ~repo ~num in
+      API.get_stream ?token ~uri (fun b -> return (labels_of_string b))
+
+    let add_labels ?token ~user ~repo ~num ~labels () =
+      let body = string_of_new_labels labels in
+      let uri = URI.issue_labels ~user ~repo ~num in
+      API.post ?token ~body ~uri ~expected_code:`OK (fun b -> return (labels_of_string b))
+
+    let remove_label ?token ~user ~repo ~num ~name () =
+      let uri = URI.issue_label ~user ~repo ~num ~name in
+      API.delete ?token ~uri ~expected_code:`No_content (fun _ -> return ())
+
+    let replace_labels ?token ~user ~repo ~num ~labels () =
+      let body = string_of_new_labels labels in
+      let uri = URI.issue_labels ~user ~repo ~num in
+      API.post ?token ~body ~uri ~expected_code:`OK (fun b -> return (labels_of_string b))
+
+    let remove_labels ?token ~user ~repo ~num () =
+      let uri = URI.issue_labels ~user ~repo ~num in
+      API.delete ?token ~uri ~expected_code:`No_content (fun b -> return ())
+
     let is_issue = function { issue_pull_request = None } -> true | _ -> false
 
     let is_pull = function { issue_pull_request = None } -> false | _ -> true
+  end
+
+  module Label = struct
+    open Lwt
+
+    let for_repo ?token ~user ~repo () =
+      let uri = URI.repo_labels ~user ~repo in
+      API.get_stream ?token ~uri (fun b -> return (labels_of_string b))
+
+    let get ?token ~user ~repo ~name () =
+      let uri = URI.repo_label ~user ~repo ~name in
+      API.get ?token ~uri (fun b -> return (label_of_string b))
+
+    let create ?token ~user ~repo ~label () =
+      let body = string_of_new_label label in
+      let uri = URI.repo_labels ~user ~repo in
+      API.post ?token ~body ~uri ~expected_code:`Created (fun b -> return (label_of_string b))
+
+    let update ?token ~user ~repo ~name ~label () =
+      let body = string_of_new_label label in
+      let uri = URI.repo_label ~user ~repo ~name in
+      API.patch ?token ~body ~uri ~expected_code:`OK (fun b -> return (label_of_string b))
+
+    let delete ?token ~user ~repo ~name () =
+      let uri = URI.repo_label ~user ~repo ~name in
+      API.delete ?token ~uri ~expected_code:`No_content (fun _ -> return ())
   end
 
   module Status = struct
@@ -1739,4 +1806,3 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       )
   end
 end
-

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -266,10 +266,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
 
     let milestone ~user ~repo ~num =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/milestones/%d" api user repo num)
-    
+
     let milestone_labels ~user ~repo ~num =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/milestones/%d/labels" api user repo num)
- 
+
     let issue_comments ~user ~repo ~num =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/%d/comments" api user repo num)
 
@@ -370,7 +370,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
 
     let user_orgs ~user =
       Uri.of_string (Printf.sprintf "%s/users/%s/orgs" api user)
- end
+  end
 
   module C = Cohttp
   module CLB = Cohttp_lwt_body

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -1420,7 +1420,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let replace_labels ?token ~user ~repo ~num ~labels () =
       let body = string_of_new_labels labels in
       let uri = URI.issue_labels ~user ~repo ~num in
-      API.post ?token ~body ~uri ~expected_code:`OK (fun b -> return (labels_of_string b))
+      API.put ?token ~body ~uri ~expected_code:`OK (fun b -> return (labels_of_string b))
 
     let remove_labels ?token ~user ~repo ~num () =
       let uri = URI.issue_labels ~user ~repo ~num in

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -1061,29 +1061,29 @@ module type Github = sig
   module Label : sig
     val for_repo :
       ?token:Token.t ->
-      user:string -> 
-      repo:string -> 
-      unit -> 
+      user:string ->
+      repo:string ->
+      unit ->
       Github_t.label Stream.t
     (** [for_repo ~user ~repo ()] is a stream of all labels in repo
         [user]/[repo]. *)
 
     val get :
       ?token:Token.t ->
-      user:string -> 
-      repo:string -> 
-      name:string -> 
-      unit -> 
+      user:string ->
+      repo:string ->
+      name:string ->
+      unit ->
       Github_t.label Response.t Monad.t
     (** [get ~user ~repo ~name ()] gets the label [name] from the
         repo [user]/[repo]. *)
 
     val create :
       ?token:Token.t ->
-      user:string -> 
-      repo:string -> 
-      label:Github_t.new_label -> 
-      unit -> 
+      user:string ->
+      repo:string ->
+      label:Github_t.new_label ->
+      unit ->
       Github_t.label Response.t Monad.t
     (** [create ~user ~repo ~label ()] creates the label [label] in the
         repo [user]/[repo]. *)
@@ -1093,7 +1093,7 @@ module type Github = sig
       user:string ->
       repo:string ->
       name:string ->
-      label:Github_t.new_label -> 
+      label:Github_t.new_label ->
       unit ->
       Github_t.label Response.t Monad.t
     (** [update ~user ~repo ~name ()] updates the label [name] in the

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -993,12 +993,121 @@ module type Github = sig
     (** [create_comment ~user ~repo ~num ~body ()] is a newly created
         issue comment on [user]/[repo]#[num] with content [body]. *)
 
+    val labels :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      num:int ->
+      unit ->
+      Github_t.label Stream.t
+    (** [labels ~user ~repo ~num ()] is a stream of all labels
+        applied to issue [num] in the repo [user]/[repo]. *)
+
+    val add_labels :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      num:int ->
+      labels:Github_t.new_labels ->
+      unit ->
+      Github_t.label list Response.t Monad.t
+    (** [add_labels ~user ~repo ~num ~labels ()] adds the labels [labels]
+        to issue [num] in the repo [user]/[repo]. *)
+
+    val remove_label :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      num:int ->
+      name:string ->
+      unit ->
+      unit Response.t Monad.t
+    (** [remove_label ~user ~repo ~num ~name ()] removes the label [name]
+        from the issue [num] in the repo [user]/[repo]. *)
+
+    val replace_labels :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      num:int ->
+      labels:Github_t.new_labels ->
+      unit ->
+      Github_t.label list Response.t Monad.t
+    (** [replace_labels ~user ~repo ~num ~labels ()] replaces the labels on
+        issue [num] in the repo [user]/[repo] with those provided in [labels]. *)
+
+    val remove_labels :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      num:int ->
+      unit ->
+      unit Response.t Monad.t
+    (** [remove_labels ~user ~repo ~num ()] removes all labels
+        from the issue [num] in the repo [user]/[repo]. *)
+
+
     val is_issue : Github_t.issue -> bool
     (** [is_issue issue] is true if [issue] is an actual issue and not
         a pull request. *)
 
     val is_pull : Github_t.issue -> bool
     (** [is_pull issue] is true if [issue] is a pull request. *)
+  end
+
+  (** The [Label] module exposes Github's
+      {{:https://developer.github.com/v3/issues/labels/}labels
+      API}. *)
+  module Label : sig
+    val for_repo :
+      ?token:Token.t ->
+      user:string -> 
+      repo:string -> 
+      unit -> 
+      Github_t.label Stream.t
+    (** [for_repo ~user ~repo ()] is a stream of all labels in repo
+        [user]/[repo]. *)
+
+    val get :
+      ?token:Token.t ->
+      user:string -> 
+      repo:string -> 
+      name:string -> 
+      unit -> 
+      Github_t.label Response.t Monad.t
+    (** [get ~user ~repo ~name ()] gets the label [name] from the
+        repo [user]/[repo]. *)
+
+    val create :
+      ?token:Token.t ->
+      user:string -> 
+      repo:string -> 
+      label:Github_t.new_label -> 
+      unit -> 
+      Github_t.label Response.t Monad.t
+    (** [create ~user ~repo ~label ()] creates the label [label] in the
+        repo [user]/[repo]. *)
+
+    val update :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      name:string ->
+      label:Github_t.new_label -> 
+      unit ->
+      Github_t.label Response.t Monad.t
+    (** [update ~user ~repo ~name ()] updates the label [name] in the
+        repo [user]/[repo]. *)
+
+    val delete :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      name:string ->
+      unit ->
+      unit Response.t Monad.t
+    (** [delete ~user ~repo ~name ()] deletes the label [name] in the
+        repo [user]/[repo] *)
   end
 
   (** The [Milestone] module exposes GitHub's
@@ -1046,6 +1155,16 @@ module type Github = sig
     (** [update ~user ~repo ~milestone ~num ()] is the updated
         milestone [num] in repo [user]/[repo] as described by
         [milestone]. *)
+
+    val labels :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      num:int ->
+      unit ->
+      Github_t.label Stream.t
+    (** [labels ~user ~repo ()] is a stream of all labels in repo
+        [user]/[repo] *)
   end
 
   (** The [Release] module provides access to GitHub's

--- a/lib_test/labels.ml
+++ b/lib_test/labels.ml
@@ -1,0 +1,22 @@
+open Lwt
+open Printf
+
+let token = Config.access_token
+let user = "ocaml"
+let repo = "opam"
+
+let t =
+  let open Github in
+  let open Monad in
+  let open Github_t in
+  run (
+    let labels = Label.for_repo ~token ~user ~repo () in
+    Stream.iter (fun label ->
+      let name = label.label_name in
+      eprintf "label %s" name;
+      return ()
+    ) labels
+  )
+
+;;
+Lwt_main.run t

--- a/opam
+++ b/opam
@@ -10,6 +10,7 @@ authors: [
   "Thomas Gazagnaire"
   "Rudi Grinberg"
   "Qi Li"
+  "Dave Tucker"
 ]
 homepage: "https://github.com/mirage/ocaml-github"
 bug-reports: "https://github.com/mirage/ocaml-github/issues"


### PR DESCRIPTION
This PR adds support for the v3 Labels API

There are a couple of methods that are currently returning `Github_t.label list Response.t Monad.t` but I believe these should "probably" be `Github_t.label Stream.t`...
Having looked at the code though, it didn't seem like a trivial change, so I though I'd push what I have in the hope that someone more experienced than I might be able to asist.

The methods in question are:
- [Add labels to an issue](https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue)
- [Replace all labels for an issue](https://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue)
