### PR TITLE
Improve webhook event actions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 1.2.0 (dev):
+* Changes marked with ! are type changes
 * Add Labels API support (#146 from @dave-tucker)
 * Add Collaborators API support
 * Make `tls` the default recommended dependency instead of OpenSSL
@@ -8,8 +9,22 @@
 * Add Stream.fold
 * Add Issue.get
 * update_issue type added
-* Change Issue.update to accept update_issue rather than new_issue
+* ! Change Issue.update to accept update_issue rather than new_issue
   This allows users to change issue state (open/close).
+* ! scope variant now has Unknown fall-back constructor
+* ! issue_sort variant now has Unknown fall-back constructor
+* ! team_permission variant now has Unknown fall-back constructor
+* ! wiki_page_action variant now has Unknown fall-back constructor
+* ! issue_comment_action variant now has Unknown fall-back constructor
+* ! issues_action variant now has Unknown fall-back constructor
+* ! member_action variant now has Unknown fall-back constructor
+* ! page_build_status variant now has Unknown fall-back constructor
+* ! pull_request_action variant now has Unknown fall-back constructor
+* ! pull_request_review_comment_action variant now has Unknown fall-back
+  constructor
+* ! release_action variant now has Unknown fall-back constructor
+* ! watch_action variant now has Unknown fall-back constructor
+* ! status_state variant now has Unknown fall-back constructor
 
 1.1.0 (2016-06-20):
 * Add new_status_context and status_context fields (#88)

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 * Add Labels API support (#146 from @dave-tucker)
 * Add Collaborators API support
 * Make `tls` the default recommended dependency instead of OpenSSL
+* Add Hook.parse_event
 * Add Repo.create
 * Add Repo.delete
 * Add Stream.fold

--- a/jar/list_events.ml
+++ b/jar/list_events.ml
@@ -111,6 +111,8 @@ let print_event event =
       (string_of_status_state status_event_state)
   | `Watch { watch_event_action = `Started } ->
     printf "WatchEvent on %s/%s\n%!" user repo
+  | `Unknown (cons, _json) ->
+    printf "UnknownEvent '%s'\n%!" cons
   );
   return ()
 

--- a/jar/list_events.ml
+++ b/jar/list_events.ml
@@ -22,6 +22,11 @@ open Printf
 let string_of_wiki_page_action = function
   | `Created -> "Created"
   | `Edited -> "Edited"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
+let string_of_issue_comment_event_action = function
+  | `Created -> "Created"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let string_of_issue user repo issue = Github_t.(
   sprintf "%s/%s#%d (%s)" user repo issue.issue_number issue.issue_title
@@ -29,11 +34,27 @@ let string_of_issue user repo issue = Github_t.(
 
 let string_of_issues_action = Github_j.string_of_issues_action
 
+let string_of_member_event_action = function
+  | `Added -> "Added"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
 let string_of_pull user repo number = sprintf "%s/%s#%d" user repo number
 
 let string_of_pull_request_action = Github_j.string_of_pull_request_action
 
+let string_of_pull_request_review_comment_action = function
+  | `Created -> "Created"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
+let string_of_release_event_action = function
+  | `Published -> "Published"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
 let string_of_status_state = Github_j.string_of_status_state
+
+let string_of_watch_event_action = function
+  | `Started -> "Started"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let print_event event =
   let open Github_t in
@@ -71,17 +92,19 @@ let print_event event =
         (string_of_wiki_page_action wiki_page_action)^" "^wiki_page_title
        ) gollum_event_pages))
   | `IssueComment {
-    issue_comment_event_action = `Created;
+    issue_comment_event_action;
     issue_comment_event_issue = issue;
     issue_comment_event_comment = comment;
   } ->
-    printf "IssueCommentEvent on %s: %s\n%!"
+    printf "IssueCommentEvent %s on %s: %s\n%!"
+      (string_of_issue_comment_event_action issue_comment_event_action)
       (string_of_issue user repo issue) comment.issue_comment_body
   | `Issues { issues_event_action = action; issues_event_issue = issue } ->
     printf "IssuesEvent on %s: %s\n%!"
       (string_of_issue user repo issue) (string_of_issues_action action)
-  | `Member { member_event_action = `Added; member_event_member = member } ->
-    printf "MemberEvent on %s/%s: %s added\n%!"
+  | `Member { member_event_action; member_event_member = member } ->
+    printf "MemberEvent %s on %s/%s: %s added\n%!"
+      (string_of_member_event_action member_event_action)
       user repo member.linked_user_login
   | `Public ->
     printf "PublicEvent on %s/%s\n%!" user repo
@@ -93,24 +116,28 @@ let print_event event =
       (string_of_pull user repo pull_request_event_number)
       (string_of_pull_request_action action)
   | `PullRequestReviewComment {
-    pull_request_review_comment_event_action = `Created;
+    pull_request_review_comment_event_action = action;
     pull_request_review_comment_event_pull_request = pull;
     pull_request_review_comment_event_comment = comment;
   } ->
-    printf "PullRequestReviewCommentEvent on %s: %s\n%!"
+    printf "PullRequestReviewCommentEvent %s on %s: %s\n%!"
+      (string_of_pull_request_review_comment_action action)
       (string_of_pull user repo pull.pull_number)
       comment.pull_request_review_comment_body
   | `Push { push_event_ref; push_event_size } ->
     printf "PushEvent on %s/%s ref %s of %d commits\n%!"
       user repo push_event_ref push_event_size
-  | `Release { release_event_action = `Published; release_event_release } ->
-    printf "ReleaseEvent on %s/%s: %s\n%!" user repo
+  | `Release { release_event_action; release_event_release } ->
+    printf "ReleaseEvent %s on %s/%s: %s\n%!" user repo
+      (string_of_release_event_action release_event_action)
       release_event_release.release_tag_name
   | `Status { status_event_state; status_event_sha } ->
     printf "StatusEvent on %s/%s: %s %s\n%!" user repo status_event_sha
       (string_of_status_state status_event_state)
-  | `Watch { watch_event_action = `Started } ->
-    printf "WatchEvent on %s/%s\n%!" user repo
+  | `Watch { watch_event_action } ->
+    printf "WatchEvent %s on %s/%s\n%!"
+      (string_of_watch_event_action watch_event_action)
+      user repo
   | `Unknown (cons, _json) ->
     printf "UnknownEvent '%s'\n%!" cons
   );

--- a/jar/listen_events.ml
+++ b/jar/listen_events.ml
@@ -111,6 +111,8 @@ let print_event event =
       (string_of_status_state status_event_state)
   | `Watch { watch_event_action = `Started } ->
     printf "WatchEvent on %s/%s\n%!" user repo
+  | `Unknown (cons, _json) ->
+    printf "UnknownEvent '%s'\n%!" cons
   );
   return ()
 

--- a/jar/listen_events.ml
+++ b/jar/listen_events.ml
@@ -22,6 +22,11 @@ open Printf
 let string_of_wiki_page_action = function
   | `Created -> "Created"
   | `Edited -> "Edited"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
+let string_of_issue_comment_event_action = function
+  | `Created -> "Created"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let string_of_issue user repo issue = Github_t.(
   sprintf "%s/%s#%d (%s)" user repo issue.issue_number issue.issue_title
@@ -29,11 +34,27 @@ let string_of_issue user repo issue = Github_t.(
 
 let string_of_issues_action = Github_j.string_of_issues_action
 
+let string_of_member_event_action = function
+  | `Added -> "Added"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
 let string_of_pull user repo number = sprintf "%s/%s#%d" user repo number
 
 let string_of_pull_request_action = Github_j.string_of_pull_request_action
 
+let string_of_pull_request_review_comment_action = function
+  | `Created -> "Created"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
+let string_of_release_event_action = function
+  | `Published -> "Published"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
+
 let string_of_status_state = Github_j.string_of_status_state
+
+let string_of_watch_event_action = function
+  | `Started -> "Started"
+  | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let print_event event =
   let open Github_t in
@@ -42,7 +63,7 @@ let print_event event =
     | user::repo::_ -> user, repo
     | [_] | [] -> failwith "nonsense repo name"
   in
-  printf "#%Ld--> %s:" event.event_id event.event_actor.user_login;
+  printf "#--> %s:" event.event_actor.user_login;
   (match event.event_payload with
   | `CommitComment { commit_comment_event_comment = comment } ->
     printf "CommitComment on %s/%s %s\n%!"
@@ -71,17 +92,19 @@ let print_event event =
         (string_of_wiki_page_action wiki_page_action)^" "^wiki_page_title
        ) gollum_event_pages))
   | `IssueComment {
-    issue_comment_event_action = `Created;
+    issue_comment_event_action;
     issue_comment_event_issue = issue;
     issue_comment_event_comment = comment;
   } ->
-    printf "IssueCommentEvent on %s: %s\n%!"
+    printf "IssueCommentEvent %s on %s: %s\n%!"
+      (string_of_issue_comment_event_action issue_comment_event_action)
       (string_of_issue user repo issue) comment.issue_comment_body
   | `Issues { issues_event_action = action; issues_event_issue = issue } ->
     printf "IssuesEvent on %s: %s\n%!"
       (string_of_issue user repo issue) (string_of_issues_action action)
-  | `Member { member_event_action = `Added; member_event_member = member } ->
-    printf "MemberEvent on %s/%s: %s added\n%!"
+  | `Member { member_event_action; member_event_member = member } ->
+    printf "MemberEvent %s on %s/%s: %s added\n%!"
+      (string_of_member_event_action member_event_action)
       user repo member.linked_user_login
   | `Public ->
     printf "PublicEvent on %s/%s\n%!" user repo
@@ -93,24 +116,28 @@ let print_event event =
       (string_of_pull user repo pull_request_event_number)
       (string_of_pull_request_action action)
   | `PullRequestReviewComment {
-    pull_request_review_comment_event_action = `Created;
+    pull_request_review_comment_event_action = action;
     pull_request_review_comment_event_pull_request = pull;
     pull_request_review_comment_event_comment = comment;
   } ->
-    printf "PullRequestReviewCommentEvent on %s: %s\n%!"
+    printf "PullRequestReviewCommentEvent %s on %s: %s\n%!"
+      (string_of_pull_request_review_comment_action action)
       (string_of_pull user repo pull.pull_number)
       comment.pull_request_review_comment_body
   | `Push { push_event_ref; push_event_size } ->
     printf "PushEvent on %s/%s ref %s of %d commits\n%!"
       user repo push_event_ref push_event_size
-  | `Release { release_event_action = `Published; release_event_release } ->
-    printf "ReleaseEvent on %s/%s: %s\n%!" user repo
+  | `Release { release_event_action; release_event_release } ->
+    printf "ReleaseEvent %s on %s/%s: %s\n%!" user repo
+      (string_of_release_event_action release_event_action)
       release_event_release.release_tag_name
   | `Status { status_event_state; status_event_sha } ->
     printf "StatusEvent on %s/%s: %s %s\n%!" user repo status_event_sha
       (string_of_status_state status_event_state)
-  | `Watch { watch_event_action = `Started } ->
-    printf "WatchEvent on %s/%s\n%!" user repo
+  | `Watch { watch_event_action } ->
+    printf "WatchEvent %s on %s/%s\n%!"
+      (string_of_watch_event_action watch_event_action)
+      user repo
   | `Unknown (cons, _json) ->
     printf "UnknownEvent '%s'\n%!" cons
   );

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -642,15 +642,25 @@ type push_event_author = {
   email: string;
 } <ocaml field_prefix="push_event_author_">
 
-type push_event_commit = {
+type push_event_commit_base = {
   url: string;
-  sha: string;
   message: string;
   author: push_event_author;
   distinct: bool;
+} <ocaml field_prefix="push_event_commit_base_">
+
+type push_event_hook_commit = {
+  id: string;
+  tree_id: string;
+  inherit push_event_commit_base
+} <ocaml field_prefix="push_event_hook_commit_">
+
+type push_event_commit = {
+  sha: string;
+  inherit push_event_commit_base
 } <ocaml field_prefix="push_event_commit_">
 
-type push_event = {
+type push_event_base = {
   ?head: string option;
   ref: string;
   ~size <ocaml default="0">: int;
@@ -659,8 +669,17 @@ type push_event = {
   ?created: bool option;
   ?deleted: bool option;
   ?forced: bool option;
+} <ocaml field_prefix="push_event_base_">
+
+type push_event = {
   commits: push_event_commit list;
+  inherit push_event_base
 } <ocaml field_prefix="push_event_">
+
+type push_event_hook = {
+  commits: push_event_hook_commit list;
+  inherit push_event_base
+} <ocaml field_prefix="push_event_hook_">
 
 type release_action = [
   | Published <json name="published">
@@ -766,6 +785,7 @@ type event_type = [
   | TeamAdd <json name="team_add">
   | Watch <json name="watch">
   | All <json name="*">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type event_constr = [
@@ -797,6 +817,39 @@ type event_constr = [
   | Status <json name="StatusEvent"> of status_event
   (*| TeamAdd <json name="team_add"> of team_add_event*)
   | Watch <json name="WatchEvent"> of watch_event
+  | Unknown <json untyped> of (string * json option)
+]
+
+type event_hook_constr = [
+  | CommitComment <json name="CommitCommentEvent"> of commit_comment_event
+  | Create <json name="CreateEvent"> of create_event
+  | Delete <json name="DeleteEvent"> of delete_event
+  (*| Deployment <json name="deployment"> of *)
+  (*| DeploymentStatus <json name="deployment_status"> of *)
+  | Download <json name="DownloadEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Follow <json name="FollowEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Fork <json name="ForkEvent"> of fork_event
+  | ForkApply <json name="ForkApplyEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Gist <json name="GistEvent">
+  (* Deprecated but there may be a payload object... *)
+  | Gollum <json name="GollumEvent"> of gollum_event
+  | IssueComment <json name="IssueCommentEvent"> of issue_comment_event
+  | Issues <json name="IssuesEvent"> of issues_event
+  | Member <json name="MemberEvent"> of member_event
+  (*| PageBuild <json name="page_build"> of page_build_event*)
+  | Public <json name="PublicEvent">
+  | PullRequest <json name="PullRequestEvent"> of pull_request_event
+  | PullRequestReviewComment <json name="PullRequestReviewCommentEvent">
+    of pull_request_review_comment_event
+  | Push <json name="PushEvent"> of push_event_hook
+  | Release <json name="ReleaseEvent"> of release_event
+  | Status <json name="StatusEvent"> of status_event
+  (*| TeamAdd <json name="team_add"> of team_add_event*)
+  | Watch <json name="WatchEvent"> of watch_event
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type event = {

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -826,16 +826,10 @@ type web_hook_config = {
 
 type json <ocaml module="Yojson.Safe"> = abstract
 
-type host_config = json wrap <ocaml
-  t="[`Raw of json | `Web of web_hook_config]"
-  wrap="fun x ->
-    let s = Yojson.Safe.to_string x in
-     try `Web (web_hook_config_of_string s)
-     with Ag_oj_run.Error _ -> `Raw x"
-  unwrap="function
-  | `Raw x -> x
-  | `Web w -> Yojson.Safe.from_string (string_of_web_hook_config w)"
->
+type hook_config = [
+  | Web <json name="web"> of web_hook_config
+  | Unknown <json untyped> of (string * json option)
+]
 
 type hook = {
   url: string;
@@ -843,23 +837,20 @@ type hook = {
   created_at: string;
   events: event_type list;
   active: bool;
-  name: string;
-  config: host_config;
+  config <json tag_field="name">: hook_config;
   id: int <ocaml repr="int64">;
 } <ocaml field_prefix="hook_">
 
 type hooks = hook list
 
 type new_hook = {
-  name: string;
-  config: host_config;
+  config <json tag_field="name">: hook_config;
   events: event_type list;
   active: bool;
 } <ocaml field_prefix="new_hook_">
 
 type update_hook = {
-  name: string;
-  config: host_config;
+  config <json tag_field="name">: hook_config;
   ?events: event_type list option;
   active: bool;
 } <ocaml field_prefix="update_hook_">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -45,6 +45,7 @@ type scope = [
   | Read_public_key <json name="read:public_key">
   | Write_public_key <json name="write:public_key">
   | Admin_public_key <json name="admin:public_key">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type app = {
@@ -99,6 +100,7 @@ type issue_sort = [
   | Created <json name="created">
   | Updated <json name="updated">
   | Comments <json name="comments">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type direction = [
@@ -180,6 +182,7 @@ type team_permission = [
   | Pull <json name="pull">
   | Push <json name="push">
   | Admin <json name="admin">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type team_info = {
@@ -305,7 +308,7 @@ type repo_branch = {
 type repo_branches = repo_branch list
 
 type obj_type = [
-    Blob <json name="blob">
+  | Blob <json name="blob">
   | Tree <json name="tree">
   | Commit <json name="commit">
   | Tag <json name="tag">
@@ -531,6 +534,7 @@ type fork_event = {
 type wiki_page_action = [
   | Created <json name="created">
   | Edited <json name="edited">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type wiki_page = {
@@ -547,6 +551,7 @@ type gollum_event = {
 
 type issue_comment_action = [
   | Created <json name="created">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type issue_comment_event = {
@@ -563,6 +568,7 @@ type issues_action = [
   | Opened <json name="opened">
   | Closed <json name="closed">
   | Reopened <json name="reopened">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type issues_event = {
@@ -574,6 +580,7 @@ type issues_event = {
 
 type member_action = [
   | Added <json name="added">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type member_event = {
@@ -590,6 +597,7 @@ type page_build_status = [
   | Building <json name="building">
   | Built <json name="built">
   | Errored <json name="errored">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type page_build = {
@@ -611,6 +619,7 @@ type pull_request_action = [
   | Closed <json name="closed">
   | Reopened <json name="reopened">
   | Synchronize <json name="synchronize">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type pull_request_event = {
@@ -621,6 +630,7 @@ type pull_request_event = {
 
 type pull_request_review_comment_action = [
   | Created <json name="created">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type pull_request_review_comment = {
@@ -683,6 +693,7 @@ type push_event_hook = {
 
 type release_action = [
   | Published <json name="published">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type release_event = {
@@ -730,6 +741,7 @@ type team_add_event = {
 
 type watch_action = [
   | Started <json name="started">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type watch_event = {
@@ -913,6 +925,7 @@ type status_state = [
   | Success <json name="success">
   | Failure <json name="failure">
   | Error <json name="error">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type status = {

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -92,6 +92,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       | `Read_public_key -> "read:public_key"
       | `Write_public_key -> "write:public_key"
       | `Admin_public_key -> "admin:public_key"
+      | `Unknown (cons, _json) -> "unknown:"^cons
 
     let of_string x : Github_t.scope option =
       match x with

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -839,6 +839,12 @@ module type Github = sig
     (** [test ~user ~repo ~id ()] activates after a [push] event
         for the lastest push to [user]/[repo] has been synthesized
         and sent to hook [id]. *)
+
+    val parse_event :
+      constr:string ->
+      payload:string -> unit -> Github_t.event_hook_constr
+    (** [parse_event ~constr ~payload ()] is the event with
+        constructor [constr] that is represented by [payload]. *)
   end
 
   (** The [Status] module provides the functionality of GitHub's

--- a/lib_test/create_hook.ml
+++ b/lib_test/create_hook.ml
@@ -24,7 +24,10 @@ let repo = "opam-repository"
 let print_hooks label = Github_t.(Github.(Stream.iter (fun hook ->
   eprintf "%s %s hook %Ld created on %s %b detecting %s\n%!"
     label
-    (match hook.hook_config with `Web _ -> "web")
+    (match hook.hook_config with
+     | `Web _ -> "web"
+     | `Unknown (cons, json) -> cons
+    )
     hook.hook_id
     hook.hook_created_at
     hook.hook_active

--- a/opam
+++ b/opam
@@ -36,7 +36,7 @@ depends: [
   "uri" {>= "1.9.0"}
   "cohttp" {>= "0.17.0"}
   "lwt" {>= "2.4.4"}
-  "atdgen" {>= "1.5.0"}
+  "atdgen" {>= "1.10.0"}
   "yojson" {>= "1.2.0"}
   "stringext"
   "lambda-term"


### PR DESCRIPTION
This PR:

 * Fixes `hook_config` which had its name changed to `host_config` in #128 inexplicably
 * Fixes the `create_hook` test
 * Fixes the discrepancy between polled and received event structures for push events (#136 and #137)
 * Adds `Hook.parse_event` to handle the construction of `event_hook_constr` after the type has been extracted from the HTTP `x-github-event` header.
 * Adds an `Unknown` variant constructor to many possibly-extensible variants to improve robustness in the face of API extensions