### PR TITLE
Fix Event.for_repo_issues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 * Add Repo.delete
 * Add Stream.fold
 * Add Issue.get
+* ! Fix Event.for_repo_issues (#107 from @yallop)
 * update_issue type added
 * Change Issue.update to accept update_issue rather than new_issue
   This allows users to change issue state (open/close).

--- a/_oasis
+++ b/_oasis
@@ -1,8 +1,8 @@
 OASISFormat: 0.4
 Name:        github
-Version:     1.1.1
+Version:     1.2.0
 Synopsis:    Github API interface
-Authors:     Anil Madhavapeddy, David Sheets, Andy Ray, Jeff Hammerbacher, Thomas Gazagnaire, Rudi Grinberg, Qi Li
+Authors:     Anil Madhavapeddy, David Sheets, Andy Ray, Jeff Hammerbacher, Thomas Gazagnaire, Rudi Grinberg, Qi Li, Dave Tucker, Jeremy Yallop
 License:     ISC
 Plugins:     META (0.4)
 BuildTools: ocamlbuild

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -565,14 +565,19 @@ type repo_issues_action = [
   | Head_ref_restored <json name="head_ref_restored">
 ]
 
-type repo_issues_event = {
+type repo_issue_event = {
   event: repo_issues_action;
-  issue: issue;
   ?assignee: user_info option;
   ?label: label option;
 } <ocaml field_prefix="issues_event_">
 
+type repo_issues_event = {
+  issue: issue;
+  inherit repo_issue_event
+} <ocaml field_prefix="issues_event_">
+
 type repo_issues_events = repo_issues_event list
+type repo_issue_events = repo_issue_event list
 
 type issue_comment_action = [
   | Created <json name="created">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -545,6 +545,35 @@ type gollum_event = {
   pages: wiki_page list;
 } <ocaml field_prefix="gollum_event_">
 
+type repo_issues_action = [
+  | Closed <json name="closed">
+  | Reopened <json name="reopened">
+  | Subscribed <json name="subscribed">
+  | Merged <json name="merged">
+  | Referenced <json name="referenced">
+  | Mentioned <json name="mentioned">
+  | Assigned <json name="assigned">
+  | Unassigned <json name="unassigned">
+  | Labeled <json name="labeled">
+  | Unlabeled <json name="unlabeled">
+  | Milestoned <json name="milestoned">
+  | Demilestoned <json name="demilestoned">
+  | Renamed <json name="renamed">
+  | Locked <json name="locked">
+  | Unlocked <json name="unlocked">
+  | Head_ref_deleted <json name="head_ref_deleted">
+  | Head_ref_restored <json name="head_ref_restored">
+]
+
+type repo_issues_event = {
+  event: repo_issues_action;
+  issue: issue;
+  ?assignee: user_info option;
+  ?label: label option;
+} <ocaml field_prefix="issues_event_">
+
+type repo_issues_events = repo_issues_event list
+
 type issue_comment_action = [
   | Created <json name="created">
 ]

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -563,6 +563,7 @@ type repo_issues_action = [
   | Unlocked <json name="unlocked">
   | Head_ref_deleted <json name="head_ref_deleted">
   | Head_ref_restored <json name="head_ref_restored">
+  | Unknown <json untyped> of (string * json option)
 ]
 
 type repo_issue_event = {

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -313,6 +313,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/events"
                        api user repo)
 
+    let repo_issue_events ~user ~repo ~num =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/%d/events"
+                       api user repo num)
+
     let public_events = Uri.of_string (Printf.sprintf "%s/events" api)
 
     let network_events ~user ~repo =
@@ -1674,6 +1678,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let for_repo_issues ?token ~user ~repo () =
       let uri = URI.repo_issues_events ~user ~repo in
       API.get_stream ?token ~uri (fun b -> return (repo_issues_events_of_string b))
+
+    let for_repo_issue ?token ~user ~repo ~num () =
+      let uri = URI.repo_issue_events ~user ~repo ~num in
+      API.get_stream ?token ~uri (fun b -> return (repo_issue_events_of_string b))
 
     let public_events () =
       let uri = URI.public_events in

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -309,7 +309,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let repo_events ~user ~repo =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/events" api user repo)
 
-    let repo_issue_events ~user ~repo =
+    let repo_issues_events ~user ~repo =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/issues/events"
                        api user repo)
 
@@ -1672,8 +1672,8 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       API.get_stream ?token ~uri (fun b -> return (events_of_string b))
 
     let for_repo_issues ?token ~user ~repo () =
-      let uri = URI.repo_issue_events ~user ~repo in
-      API.get_stream ?token ~uri (fun b -> return (events_of_string b))
+      let uri = URI.repo_issues_events ~user ~repo in
+      API.get_stream ?token ~uri (fun b -> return (repo_issues_events_of_string b))
 
     let public_events () =
       let uri = URI.public_events in

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -629,7 +629,7 @@ module type Github = sig
     val for_repo_issues :
       ?token:Token.t ->
       user:string ->
-      repo:string -> unit -> Github_t.event Stream.t
+      repo:string -> unit -> Github_t.repo_issues_event Stream.t
     (** [for_repo_issues ~user ~repo ()] is a stream of all issue
         events for [user]/[repo]. *)
 

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -633,6 +633,14 @@ module type Github = sig
     (** [for_repo_issues ~user ~repo ()] is a stream of all issue
         events for [user]/[repo]. *)
 
+    val for_repo_issue :
+      ?token:Token.t ->
+      user:string ->
+      repo:string -> 
+      num:int -> unit -> Github_t.repo_issue_event Stream.t
+    (** [for_repo_issue ~user ~repo ~num ()] is a stream of all issue
+        events for [user]/[repo]/issues/[num]. *)
+
     val public_events : unit -> Github_t.event Stream.t
     (** [public_events ()] is a stream of all public events on GitHub. *)
 

--- a/opam
+++ b/opam
@@ -10,6 +10,7 @@ authors: [
   "Thomas Gazagnaire"
   "Rudi Grinberg"
   "Qi Li"
+  "Jeremy Yallop"
   "Dave Tucker"
 ]
 homepage: "https://github.com/mirage/ocaml-github"


### PR DESCRIPTION
This is a revision of #134 that fixes #107 (like #134) but brings the API up-to-date wrt variant constructor fall-backs.