### PR TITLE
Print custom error messages on GitHub errors

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -2,6 +2,7 @@ type error = {
   resource: string;
   ?field: string option;
   code: string;
+  ?message: string option;
 } <ocaml field_prefix="error_">
 
 type message = {

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -23,14 +23,20 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
 
   let string_of_message message =
     message.Github_t.message_message^
-    (List.fold_left
-       (fun s {Github_t.error_resource; error_field; error_code} ->
+    Github_t.(List.fold_left
+       (fun s { error_resource; error_field; error_code; error_message; } ->
           let error_field = match error_field with
             | None -> "\"\""
             | Some x -> x
           in
-          Printf.sprintf "%s\n> Resource type: %s\n  Field: %s\n  Code: %s"
-            s error_resource error_field error_code)
+          let error_message = match error_message with
+            | None -> "\"\""
+            | Some x -> x
+          in
+          Printf.sprintf
+            "%s\n> Resource type: %s\n  Field: %s\n  Code: %s\n  Message: %s"
+            s error_resource error_field error_code error_message
+       )
        "" message.Github_t.message_errors)
 
   exception Message of Cohttp.Code.status_code * Github_t.message


### PR DESCRIPTION
Should help understand docker/datakit#254. The documentation of the error type is not clear about which object(s) have 'message' fields but I found examples that suggest that each individual error object should have a message.