### PR TITLE
Combined status bindings (Status.get)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
 * Add Repo.delete
 * Add Stream.fold
 * Add Issue.get
+* Add Status.get
 * ! Fix Event.for_repo_issues (#107 from @yallop)
 * update_issue type added
 * ! Change Issue.update to accept update_issue rather than new_issue

--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
    status](https://developer.github.com/v3/repos/statuses/#create-a-status)
  * [List statuses for a specific
    ref](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref)
+ * [Get the combined status for a specific
+   ref](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref)
  * [List contributors](https://developer.github.com/v3/repos/#list-contributors)
  * Most [Webhooks](https://developer.github.com/v3/repos/hooks/) endpoints
  * [Get contributors list with additions, deletions, and commit counts](https://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts)
@@ -276,8 +278,6 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Get the number of additions and deletions per week](https://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
  * [Get the weekly commit count for the repository owner and everyone else](https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repository-owner-and-everyone-else) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
  * [Get the number of commits per hour in each day](https://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
- * [Get the combined status for a specific
-   ref](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref)
  * [Ping a
    hook](https://developer.github.com/v3/repos/hooks/#ping-a-hook)
  * [PubSubHubbub](https://developer.github.com/v3/repos/hooks/#pubsubhubbub)

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -964,7 +964,7 @@ type status_state = [
   | Unknown <json untyped> of (string * json option)
 ]
 
-type status = {
+type base_status = {
   url: string;
   updated_at: string;
   created_at: string;
@@ -972,11 +972,27 @@ type status = {
   state: status_state;
   ?target_url: string option;
   ?description: string option;
-  creator: user;
   ?context: string option;
+} <ocaml field_prefix="base_status_">
+
+type base_statuses = base_status list
+
+type status = {
+  creator: user;
+  inherit base_status
 } <ocaml field_prefix="status_">
 
 type statuses = status list
+
+type combined_status = {
+  state: status_state;
+  sha: string;
+  total_count: int;
+  statuses: base_statuses;
+  repository: repo;
+  url: string;
+  commit_url: string;
+} <ocaml field_prefix="combined_status_">
 
 type new_status = {
   state: status_state;

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -244,6 +244,9 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
     let repo_commit ~user ~repo ~sha =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/commits/%s" api user repo sha)
 
+    let repo_commit_status ~user ~repo ~git_ref =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/commits/%s/status" api user repo git_ref)
+
     let repo_statuses ~user ~repo ~git_ref =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/statuses/%s" api user repo git_ref)
 
@@ -1567,6 +1570,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
       let uri = URI.repo_statuses ~user ~repo ~git_ref:sha in
       let body = string_of_new_status status in
       API.post ~body ?token ~uri ~expected_code:`Created (fun b -> return (status_of_string b))
+
+    let get ?token ~user ~repo ~sha () =
+      let uri = URI.repo_commit_status ~user ~repo ~git_ref:sha in
+      API.get ?token ~uri (fun b -> return (combined_status_of_string b))
   end
 
   module Hook = struct

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -893,6 +893,15 @@ module type Github = sig
       unit -> Github_t.status Response.t Monad.t
     (** [create ~user ~repo ~sha ~status ()] is a newly created status
         on SHA [sha] in repo [user]/[repo] as described by [status]. *)
+
+    val get :
+      ?token:Token.t ->
+      user:string ->
+      repo:string ->
+      sha:string ->
+      unit -> Github_t.combined_status Response.t Monad.t
+    (** [get ~user ~repo ~sha ()] is the combined status of the ref
+        [sha] in the repo [user]/[repo]. *)
   end
 
   (** The [Pull] module contains functionality relating to GitHub's


### PR DESCRIPTION
`Status.get` implements <https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref>.