### PR TITLE
Edited event constructors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@
 * ! issue_sort variant now has Unknown fall-back constructor
 * ! team_permission variant now has Unknown fall-back constructor
 * ! wiki_page_action variant now has Unknown fall-back constructor
+* ! issue_comment_action variant now has Edited constructor
+* ! issue_comment_action variant now has Deleted constructor
 * ! issue_comment_action variant now has Unknown fall-back constructor
 * ! issues_action variant now has Edited constructor
 * ! issues_action variant now has Unknown fall-back constructor

--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@
 * ! issues_action variant now has Unknown fall-back constructor
 * ! member_action variant now has Unknown fall-back constructor
 * ! page_build_status variant now has Unknown fall-back constructor
+* ! pull_request_action variant now has Edited constructor
 * ! pull_request_action variant now has Unknown fall-back constructor
 * ! pull_request_review_comment_action variant now has Unknown fall-back
   constructor

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@
 * ! team_permission variant now has Unknown fall-back constructor
 * ! wiki_page_action variant now has Unknown fall-back constructor
 * ! issue_comment_action variant now has Unknown fall-back constructor
+* ! issues_action variant now has Edited constructor
 * ! issues_action variant now has Unknown fall-back constructor
 * ! member_action variant now has Unknown fall-back constructor
 * ! page_build_status variant now has Unknown fall-back constructor

--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,8 @@
 * ! page_build_status variant now has Unknown fall-back constructor
 * ! pull_request_action variant now has Edited constructor
 * ! pull_request_action variant now has Unknown fall-back constructor
+* ! pull_request_review_comment_action variant now has Edited constructor
+* ! pull_request_review_comment_action variant now has Deleted constructor
 * ! pull_request_review_comment_action variant now has Unknown fall-back
   constructor
 * ! release_action variant now has Unknown fall-back constructor

--- a/jar/list_events.ml
+++ b/jar/list_events.ml
@@ -26,6 +26,8 @@ let string_of_wiki_page_action = function
 
 let string_of_issue_comment_event_action = function
   | `Created -> "Created"
+  | `Edited _ -> "Edited"
+  | `Deleted -> "Deleted"
   | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let string_of_issue user repo issue = Github_t.(
@@ -44,6 +46,8 @@ let string_of_pull_request_action = Github_j.string_of_pull_request_action
 
 let string_of_pull_request_review_comment_action = function
   | `Created -> "Created"
+  | `Edited _ -> "Edited"
+  | `Deleted -> "Deleted"
   | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let string_of_release_event_action = function

--- a/jar/listen_events.ml
+++ b/jar/listen_events.ml
@@ -26,6 +26,8 @@ let string_of_wiki_page_action = function
 
 let string_of_issue_comment_event_action = function
   | `Created -> "Created"
+  | `Edited _ -> "Edited"
+  | `Deleted -> "Deleted"
   | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let string_of_issue user repo issue = Github_t.(
@@ -44,6 +46,8 @@ let string_of_pull_request_action = Github_j.string_of_pull_request_action
 
 let string_of_pull_request_review_comment_action = function
   | `Created -> "Created"
+  | `Edited _ -> "Edited"
+  | `Deleted -> "Deleted"
   | `Unknown (cons, _json) -> "Unknown:"^cons
 
 let string_of_release_event_action = function

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -683,6 +683,8 @@ type pull_request_event = {
 
 type pull_request_review_comment_action = [
   | Created <json name="created">
+  | Edited <json name="edited"> of body_changes
+  | Deleted <json name="deleted">
   | Unknown <json untyped> of (string * json option)
 ]
 
@@ -695,7 +697,7 @@ type pull_request_review_comment = {
 } <ocaml field_prefix="pull_request_review_comment_">
 
 type pull_request_review_comment_event = {
-  action: pull_request_review_comment_action;
+  action <json name="changes" tag_field="action">: pull_request_review_comment_action;
   pull_request: pull;
   comment: pull_request_review_comment;
 } <ocaml field_prefix="pull_request_review_comment_event_">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -668,6 +668,7 @@ type pull_request_action = [
   | Labeled <json name="labeled">
   | Unlabeled <json name="unlabeled">
   | Opened <json name="opened">
+  | Edited <json name="edited"> of ticket_changes
   | Closed <json name="closed">
   | Reopened <json name="reopened">
   | Synchronize <json name="synchronize">
@@ -675,7 +676,7 @@ type pull_request_action = [
 ]
 
 type pull_request_event = {
-  action: pull_request_action;
+  action <json name="changes" tag_field="action">: pull_request_action;
   number: int;
   pull_request: pull;
 } <ocaml field_prefix="pull_request_event_">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -596,11 +596,13 @@ type issue_changes = {
 
 type issue_comment_action = [
   | Created <json name="created">
+  | Edited <json name="edited"> of issue_changes
+  | Deleted <json name="deleted">
   | Unknown <json untyped> of (string * json option)
 ]
 
 type issue_comment_event = {
-  action: issue_comment_action;
+  action <json name="changes" tag_field="action">: issue_comment_action;
   issue: issue;
   comment: issue_comment;
 } <ocaml field_prefix="issue_comment_event_">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -589,14 +589,18 @@ type change = {
   from: string;
 } <ocaml field_prefix="change_">
 
-type issue_changes = {
-  ?title: change option;
+type body_changes = {
   ?body: change option;
-} <ocaml field_prefix="issue_changes_">
+} <ocaml field_prefix="body_changes_">
+
+type ticket_changes = {
+  ?title: change option;
+  inherit body_changes
+} <ocaml field_prefix="ticket_changes_">
 
 type issue_comment_action = [
   | Created <json name="created">
-  | Edited <json name="edited"> of issue_changes
+  | Edited <json name="edited"> of body_changes
   | Deleted <json name="deleted">
   | Unknown <json untyped> of (string * json option)
 ]
@@ -613,7 +617,7 @@ type issues_action = [
   | Labeled <json name="labeled">
   | Unlabeled <json name="unlabeled">
   | Opened <json name="opened">
-  | Edited <json name="edited"> of issue_changes
+  | Edited <json name="edited"> of ticket_changes
   | Closed <json name="closed">
   | Reopened <json name="reopened">
   | Unknown <json untyped> of (string * json option)

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -585,6 +585,15 @@ type repo_issues_event = {
 type repo_issues_events = repo_issues_event list
 type repo_issue_events = repo_issue_event list
 
+type change = {
+  from: string;
+} <ocaml field_prefix="change_">
+
+type issue_changes = {
+  ?title: change option;
+  ?body: change option;
+} <ocaml field_prefix="issue_changes_">
+
 type issue_comment_action = [
   | Created <json name="created">
   | Unknown <json untyped> of (string * json option)
@@ -602,13 +611,14 @@ type issues_action = [
   | Labeled <json name="labeled">
   | Unlabeled <json name="unlabeled">
   | Opened <json name="opened">
+  | Edited <json name="edited"> of issue_changes
   | Closed <json name="closed">
   | Reopened <json name="reopened">
   | Unknown <json untyped> of (string * json option)
 ]
 
 type issues_event = {
-  action: issues_action;
+  action <json name="changes" tag_field="action">: issues_action;
   issue: issue;
   ?assignee: user_info option;
   ?label: label option;


### PR DESCRIPTION
Now the pre-edit information is available when receiving an event about an issue edit. Introduced by <https://developer.github.com/changes/2016-04-18-new-webhook-actions-are-live/>.