### PR TITLE
Remove general URI endpoint interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@
 * Improve GitHub error reporting (#151)
 * Add Organization.user_orgs (#130 from @yallop)
 * Add Hook.parse_event
+* Add event_hook_constr type for the web hook event variants
 * Add Repo.create
 * Add Repo.delete
 * Add Stream.fold

--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,7 @@
 * Make `tls` the default recommended dependency instead of OpenSSL
 * Require atdgen >= 1.10.0 for <json untyped> support
 * Add HTTP redirect support (Response.redirect(s) and Response.final_resource)
+* Add Organization.user_orgs (#130 from @yallop)
 * Add Hook.parse_event
 * Add Repo.create
 * Add Repo.delete

--- a/CHANGES
+++ b/CHANGES
@@ -5,8 +5,10 @@
 * update_issue type added
 * ! Change Issue.update to accept update_issue rather than new_issue
   This allows users to change issue state (open/close).
+* ! event_type now has Repository constructor
+* ! event_type now has All constructor
+* ! event_type now has Unknown fall-back constructor
 * ! event_constr now has Repository constructor
-* ! event_hook_constr now has Repository constructor
 * ! scope variant now has Unknown fall-back constructor
 * ! issue_sort variant now has Unknown fall-back constructor
 * ! team_permission variant now has Unknown fall-back constructor

--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,7 @@
 * Make `tls` the default recommended dependency instead of OpenSSL
 * Require atdgen >= 1.10.0 for <json untyped> support
 * Add HTTP redirect support (Response.redirect(s) and Response.final_resource)
+* Improve GitHub error reporting (#151)
 * Add Organization.user_orgs (#130 from @yallop)
 * Add Hook.parse_event
 * Add Repo.create

--- a/CHANGES
+++ b/CHANGES
@@ -30,7 +30,14 @@
 * ! watch_action variant now has Unknown fall-back constructor
 * ! status_state variant now has Unknown fall-back constructor
 * ! update_pull_base field added (PR target branch is now updatable)
-* ! URI.issue_comment signature changed
+* ! URI.repo_issues was removed
+* ! URI.repo_issue was removed
+* ! URI.repo_pulls was removed
+* ! URI.repo_milestones was removed
+* ! URI.repo_contributors_stats was removed
+* ! URI.issue_comments was removed
+* ! URI.issue_comment was removed
+* ! URI.milestone was removed
 * ! Issue.comments signature changed
 * Add Labels API support (#146 from @dave-tucker)
 * Add Collaborators API support

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -451,38 +451,6 @@ module type Github = sig
     (** [token ~client_id ~client_secret ~code ()] is the API endpoint
         used by {!Token.of_code} to finish the OAuth2 web flow and
         convert a temporary OAuth code into a real API access token. *)
-
-    val repo_issues : user:string -> repo:string -> Uri.t
-    (** [repo_issues ~user ~repo] is the API endpoint for all issues
-        on repo [user]/[repo]. *)
-
-    val repo_issue : user:string -> repo:string -> num:int ->  Uri.t
-    (** [repo_issue ~user ~repo ~num] is the API endpoint for the
-        issue [user]/[repo]#[num]. *)
-
-    val repo_pulls : user:string -> repo:string -> Uri.t
-    (** [repo_pulls ~user ~repo] is the API endpoint for all pull
-        requests on repo [user]/[repo]. *)
-
-    val repo_milestones : user:string -> repo:string -> Uri.t
-    (** [repo_milestones ~user ~repo] is the API endpoint for all
-        milestones on repo [user]/[repo]. *)
-
-    val repo_contributors_stats : user:string -> repo:string -> Uri.t
-    (** [repo_contributors_stats ~user ~repo] is the API endpoint for
-        contributors' statistics on repo [user]/[repo]*)
-
-    val issue_comments: user:string -> repo:string -> num:int -> Uri.t
-    (** [issue_comments ~user ~repo ~num] is the API endpoint
-        for the comments on issue [user]/[repo]#[num]. *)
-
-    val issue_comment: user:string -> repo:string -> id:int64 -> Uri.t
-    (** [issue_comment ~user ~repo ~id] is the API endpoint for
-        comment [id] in repo [user]/[repo]. *)
-
-    val milestone : user:string -> repo:string -> num:int -> Uri.t
-    (** [milestone ~user ~repo] is the API endpoint for milestone
-        [num] on repo [user]/[repo]. *)
   end
 
   (** The [Filter] module contains types used by search and


### PR DESCRIPTION
We don't want to offer all GitHub URIs in the interface as the surface area is very large and users can easily construct their own -- the library is intended to provide typed bindings to-and-from the GitHub API and not a(n incomplete) directory of GitHub API endpoints.

On top of #164.