### PR TITLE
Fix Issue.events label field

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+2.0.3 (2016-09-30):
+* Changes marked with ! are type changes
+* ! repo_issue_event_label and repo_issues_event_label have changed type
+  from label option to base_label option as the GitHub APIs for Issue
+  Events and Issue Labels are not consistent with the inclusion of the
+  url field
+* base_label type added (label without the url field)
+
 2.0.2 (2016-09-26):
 * Changes marked with ! are type changes
 * ! Issue.remove_label now returns a label list Response.t Monad.t like

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -196,10 +196,14 @@ type team_info = {
 
 type team_infos = team_info list
 
-type label = {
-  url: string;
+type base_label = {
   name: string;
   color: string;
+} <ocaml field_prefix="base_label_">
+
+type label = {
+  url: string;
+  inherit base_label
 } <ocaml field_prefix="label_">
 
 type labels = label list
@@ -583,7 +587,7 @@ type repo_issue_event = {
   actor: linked_user;
   event: repo_issues_action;
   created_at: string;
-  ?label: label option;
+  ?label: base_label option;
   ?assignee: linked_user option;
   ?assigner: linked_user option;
   ?milestone: milestone option;


### PR DESCRIPTION
`repo_issue_event_label` and `repo_issues_event_label` have changed type from `label option` to `base_label option` as the GitHub APIs for Issue Events and Issue Labels are not consistent with the inclusion of the `url` field.