### PR TITLE
parse_event now also return the event metadata

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -920,6 +920,18 @@ type event_constr = [
   | Unknown <json untyped> of (string * json option)
 ]
 
+type event = {
+  public: bool;
+  payload <json tag_field="type">: event_constr;
+  actor: user;
+  ?org: org option;
+  created_at: string;
+  repo: repo;
+  id: int <ocaml repr="int64">;
+} <ocaml field_prefix="event_">
+
+type events = event list
+
 type event_hook_constr = [
   | CommitComment <json name="CommitCommentEvent"> of commit_comment_event
   | Create <json name="CreateEvent"> of create_event
@@ -953,17 +965,13 @@ type event_hook_constr = [
   | Unknown <json untyped> of (string * json option)
 ]
 
-type event = {
-  public: bool;
-  payload <json tag_field="type">: event_constr;
-  actor: user;
-  ?org: org option;
+type event_hook_metadata = {
+  sender: user;
+  ?organisation: org option;
   created_at: string;
-  repo: repo;
+  repository: repository;
   id: int <ocaml repr="int64">;
-} <ocaml field_prefix="event_">
-
-type events = event list
+} <ocaml field_prefix="event_hook_metadata_">
 
 type bool_as_string = string wrap <ocaml
   t="bool"

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -1684,7 +1684,6 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
         | "" -> None
         | s -> Some (Yojson.Safe.from_string s)
       in
-      Github_j.event_hook_metadata_of_string payload,
       match Github_j.event_type_of_string ("\"" ^ constr ^ "\"") with
       | `CommitComment ->
         `CommitComment (Github_j.commit_comment_event_of_string payload)
@@ -1732,6 +1731,9 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
         `Watch (Github_j.watch_event_of_string payload)
       | `All -> `Unknown ("*", parse_json payload)
       | `Unknown (cons,_) -> `Unknown (cons, parse_json payload)
+
+    let parse_event_metadata ~payload () =
+      Github_j.event_hook_metadata_of_string payload
   end
 
   module Git_obj = struct

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -1684,6 +1684,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.Client)
         | "" -> None
         | s -> Some (Yojson.Safe.from_string s)
       in
+      Github_j.event_hook_metadata_of_string payload,
       match Github_j.event_type_of_string ("\"" ^ constr ^ "\"") with
       | `CommitComment ->
         `CommitComment (Github_j.commit_comment_event_of_string payload)

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -870,10 +870,14 @@ module type Github = sig
 
     val parse_event :
       constr:string ->
-      payload:string -> unit ->
-      Github_t.event_hook_metadata * Github_t.event_hook_constr
+      payload:string -> unit -> Github_t.event_hook_constr
     (** [parse_event ~constr ~payload ()] is the event with
         constructor [constr] that is represented by [payload]. *)
+
+    val parse_event_metadata :
+      payload:string -> unit -> Github_t.event_hook_metadata
+    (** [parse_event_metadata ~payload ()] is the event metadata for
+        the serialized event [payload]. *)
   end
 
   (** The [Status] module provides the functionality of GitHub's

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -870,7 +870,8 @@ module type Github = sig
 
     val parse_event :
       constr:string ->
-      payload:string -> unit -> Github_t.event_hook_constr
+      payload:string -> unit ->
+      Github_t.event_hook_metadata * Github_t.event_hook_constr
     (** [parse_event ~constr ~payload ()] is the event with
         constructor [constr] that is represented by [payload]. *)
   end


### PR DESCRIPTION
e.g. the events' repository, sender, org, etc