### PR TITLE
Add support for the Issue Timeline API

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -1193,7 +1193,6 @@ type update_gist = {
   files: (string * update_gist) list <json repr="object">
 } <ocaml field_prefix="update_gist_">
 
-
 type emojis = (string * string) list <json repr="object">
 
 type timeline_action = [
@@ -1223,22 +1222,12 @@ type timeline_action = [
   | Unsubscribed <json name="unsubscribed">
 ]
 
-type rename = {
-  from: string;
-  to_: string <json name="to">;
-} <ocaml field_prefix="rename_">
-
-type source = {
+type timeline_source = {
   ?id: int option <ocaml repr="int64 option">;
   ?url: string option;
   ?actor: user option;
   ?issue: issue option;
-} <ocaml field_prefix="source_">
-
-type timeline_label = {
-  name: string;
-  color: string;
-} <ocaml field_prefix="timeline_label_">
+} <ocaml field_prefix="timeline_source_">
 
 type timeline_event = {
   ?id: int option <ocaml repr="int64 option">;
@@ -1247,11 +1236,11 @@ type timeline_event = {
   ?commit_id: string option;
   event: timeline_action;
   created_at: string;
-  ?label: timeline_label option;
+  ?label: base_label option;
   ?assignee: user option;
   ?milestone: milestone option;
-  ?source: source option;
-  ?rename: rename option;
+  ?source: timeline_source option;
+  ?rename: issue_rename option;
 } <ocaml field_prefix="timeline_event_">
 
 type timeline_events = timeline_event list

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -1193,4 +1193,66 @@ type update_gist = {
   files: (string * update_gist) list <json repr="object">
 } <ocaml field_prefix="update_gist_">
 
+
 type emojis = (string * string) list <json repr="object">
+
+type timeline_action = [
+  | Assigned <json name="assigned">
+  | Closed <json name="closed">
+  | Commented <json name="commented">
+  | Committed <json name="committed">
+  | Cross_referenced <json name="cross-referenced">
+  | Demilestoned <json name="demilestoned">
+  | Head_ref_deleted <json name="head_ref_deleted">
+  | Head_ref_restored <json name="head_ref_restored">
+  | Labeled <json name="labeled">
+  | Locked <json name="locked">
+  | Mentioned <json name="mentioned">
+  | Merged <json name="merged">
+  | Milestoned <json name="milestoned">
+  | Referenced <json name="referenced">
+  | Renamed <json name="renamed">
+  | Reopened <json name="reopened">
+  | Review_dismissed <json name="review_dismissed">
+  | Review_requested <json name="review_requested">
+  | Review_request_removed <json name="review_request_removed">
+  | Subscribed <json name="subscribed">
+  | Unassigned <json name="unassigned">
+  | Unlabeled <json name="unlabeled">
+  | Unlocked <json name="unlocked">
+  | Unsubscribed <json name="unsubscribed">
+]
+
+type rename = {
+  from: string;
+  to_: string <json name="to">;
+} <ocaml field_prefix="rename_">
+
+type source = {
+  ?id: int option <ocaml repr="int64 option">;
+  ?url: string option;
+  ?actor: user option;
+  ?issue: issue option;
+} <ocaml field_prefix="source_">
+
+type timeline_label = {
+  name: string;
+  color: string;
+} <ocaml field_prefix="timeline_label_">
+
+type timeline_event = {
+  ?id: int option <ocaml repr="int64 option">;
+  ?url: string option;
+  ?actor: user option;
+  ?commit_id: string option;
+  event: timeline_action;
+  created_at: string;
+  ?label: timeline_label option;
+  ?assignee: user option;
+  ?milestone: milestone option;
+  ?source: source option;
+  ?rename: rename option;
+} <ocaml field_prefix="timeline_event_">
+
+type timeline_events = timeline_event list
+

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -339,21 +339,6 @@ module type Github = sig
         fires for responses with status [expected_code] and applies
         [parse]. *)
 
-    (** The [Media_type] module exposes a range of HTTP [Accept]
-        header values suitable for use in GitHub API requests *)
-    module Media_type : sig
-      val v3 : string
-      (** [v3] corresponds to [application/vnd.github.v3+json], the
-          media-type used by the
-          {{:https://developer.github.com/v3/} GitHub API v3} *)
-
-      val experimental : string
-      (** [experimental] corresponds to
-          [application/vnd.github.mockingbird-preview], the media-type
-          used by some experimental GitHub API bindings, such as 
-          {{:https://developer.github.com/v3/issues/timeline/} timeline} *)
-    end
-
     val get :
       ?rate:rate ->
       ?fail_handlers:'a parse handler list ->
@@ -1058,7 +1043,6 @@ module type Github = sig
     val timeline_events :
       ?token:Token.t -> user:string -> repo:string -> num:int -> unit ->
       Github_t.timeline_event Stream.t
-
     (** [timeline_events ~user ~repo ~num ()] is a stream of all timeline
         events for [user]/[repo]#[num]. *)
 

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -339,10 +339,26 @@ module type Github = sig
         fires for responses with status [expected_code] and applies
         [parse]. *)
 
+    (** The [Media_type] module exposes a range of HTTP [Accept]
+        header values suitable for use in GitHub API requests *)
+    module Media_type : sig
+      val v3 : string
+      (** [v3] corresponds to [application/vnd.github.v3+json], the
+          media-type used by the
+          {{:https://developer.github.com/v3/} GitHub API v3} *)
+
+      val experimental : string
+      (** [experimental] corresponds to
+          [application/vnd.github.mockingbird-preview], the media-type
+          used by some experimental GitHub API bindings, such as 
+          {{:https://developer.github.com/v3/issues/timeline/} timeline} *)
+    end
+
     val get :
       ?rate:rate ->
       ?fail_handlers:'a parse handler list ->
       ?expected_code:Cohttp.Code.status_code ->
+      ?media_type:string ->
       ?headers:Cohttp.Header.t ->
       ?token:Token.t ->
       ?params:(string * string) list ->
@@ -364,6 +380,7 @@ module type Github = sig
       ?rate:rate ->
       ?fail_handlers:'a Stream.parse handler list ->
       ?expected_code:Cohttp.Code.status_code ->
+      ?media_type:string ->
       ?headers:Cohttp.Header.t ->
       ?token:Token.t ->
       ?params:(string * string) list ->
@@ -1037,6 +1054,13 @@ module type Github = sig
       num:int -> unit -> Github_t.repo_issue_event Stream.t
     (** [events ~user ~repo ~num ()] is a stream of all issue events
         for [user]/[repo]#[num]. *)
+
+    val timeline_events :
+      ?token:Token.t -> user:string -> repo:string -> num:int -> unit ->
+      Github_t.timeline_event Stream.t
+
+    (** [timeline_events ~user ~repo ~num ()] is a stream of all timeline
+        events for [user]/[repo]#[num]. *)
 
     val comments :
       ?token:Token.t -> ?since:string -> user:string -> repo:string ->


### PR DESCRIPTION
This PR adds support for the experimental [Issue Timeline API](https://developer.github.com/v3/issues/timeline/), which exposes a variety of events not available in standard issue event streams, including repository cross-references.

Experiments reveal that many of the fields, including `id`, are not returned in every case, and so the new types mark most of the fields as optional (17c9e5f).

The timeline API uses a distinct media-type (`application/vnd.github.mockingbird-preview`), and so the `get` function now accepts an additional optional argument (42fd1dc).