### PR TITLE
Remove m4 from the appveyor build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"


### PR DESCRIPTION
The appveyor CI is [failing](https://ci.appveyor.com/project/avsm/ocaml-github/build/1.0.189) on recent PRs (e.g. #186) with what appears to be the same problem as seen [elsewhere](https://ci.appveyor.com/project/samoht/ocaml-conduit/build/1.0.144):

```
the following programs are not installed properly:
 m4
I can't proceed :(
```

so I've applied a similar fix (cf. https://github.com/mirage/ocaml-conduit/pull/207/commits/4e1f1b2d5cfd4a346dfa47912d05027d8e8da1f1)