### PR TITLE
TLS isn't a hard dependency of github

### DIFF
--- a/github-unix.opam
+++ b/github-unix.opam
@@ -30,7 +30,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "github"
   "cohttp-lwt-unix"
-  "tls"
   "stringext"
   "lambda-term"
   "cmdliner" {>= "0.9.8"}


### PR DESCRIPTION
openssl can be used just as well and tls is pretty hard to install at the moment

@avsm as discussed. Users should just pick a backend on their own