### PR TITLE
Make contributor stats author field nullable

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -443,7 +443,7 @@ type contribution_week = {
 } <ocaml field_prefix="repo_contribution_week_">
 
 type contributor_stats = {
-  author: user;
+  author: user nullable;
   total: int;
   weeks: contribution_week list;
 } <ocaml field_prefix="repo_contributor_stats_">

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -8,7 +8,8 @@
    (current_user
     rwo
     get_token
-    repo_info))))
+    repo_info
+    contributors))))
 
 (rule
  ((targets (config.ml))
@@ -21,4 +22,5 @@
    (current_user.exe
     rwo.exe
     get_token.exe
-    repo_info.exe))))
+    repo_info.exe
+    contributors.exe))))


### PR DESCRIPTION
Turns out the author field can be null for contributors in stats (see `"author": null` in https://api.github.com/repos/dashpay/trezor-mcu/stats/contributors)

I updated `lib_test/contributors.ml` to make sure tests pass (though `contributors.exe`isn't in the build rules; not sure why... so I enabled it)