### PR TITLE
WIP: Changes needed to support latest atdgen (json adapters)

### DIFF
--- a/jar/list_events.ml
+++ b/jar/list_events.ml
@@ -22,7 +22,7 @@ open Printf
 let string_of_wiki_page_action = function
   | `Created -> "Created"
   | `Edited -> "Edited"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let string_of_issue_comment_event_action = function
   | `Created -> "Created"
@@ -38,7 +38,7 @@ let string_of_issues_action = Github_j.string_of_issues_action
 
 let string_of_member_event_action = function
   | `Added -> "Added"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let string_of_pull user repo number = sprintf "%s/%s#%d" user repo number
 
@@ -52,13 +52,13 @@ let string_of_pull_request_review_comment_action = function
 
 let string_of_release_event_action = function
   | `Published -> "Published"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let string_of_status_state = Github_j.string_of_status_state
 
 let string_of_watch_event_action = function
   | `Started -> "Started"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let print_event event =
   let open Github_t in

--- a/jar/listen_events.ml
+++ b/jar/listen_events.ml
@@ -22,7 +22,7 @@ open Printf
 let string_of_wiki_page_action = function
   | `Created -> "Created"
   | `Edited -> "Edited"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let string_of_issue_comment_event_action = function
   | `Created -> "Created"
@@ -38,7 +38,7 @@ let string_of_issues_action = Github_j.string_of_issues_action
 
 let string_of_member_event_action = function
   | `Added -> "Added"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let string_of_pull user repo number = sprintf "%s/%s#%d" user repo number
 
@@ -52,13 +52,13 @@ let string_of_pull_request_review_comment_action = function
 
 let string_of_release_event_action = function
   | `Published -> "Published"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let string_of_status_state = Github_j.string_of_status_state
 
 let string_of_watch_event_action = function
   | `Started -> "Started"
-  | `Unknown (cons, _json) -> "Unknown:"^cons
+  | `Unknown cons -> "Unknown:"^cons
 
 let print_event event =
   let open Github_t in

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -538,13 +538,13 @@ type create_event = {
   ?description: string option;
   (* pusher_type *)
 } <ocaml field_prefix="create_event_">
-  <json adapter.ocaml="Github_json.Adapter.Ref_type">
+  <json adapter.ocaml="Github_json.Adapter.Ref">
 
 type delete_event = {
   ref <json tag_field="ref_type">: ref;
   (* pusher_type *)
 } <ocaml field_prefix="delete_event_">
-  <json adapter.ocaml="Github_json.Adapter.Ref_type">
+  <json adapter.ocaml="Github_json.Adapter.Ref">
 
 type fork_event = {
   forkee: repository;
@@ -586,7 +586,7 @@ type repo_issues_action = [
   | Unlocked <json name="unlocked">
   | Head_ref_deleted <json name="head_ref_deleted">
   | Head_ref_restored <json name="head_ref_restored">
-  | Unknown string
+  | Unknown of string
 ] <json open_enum>
 
 type issue_rename = {
@@ -640,7 +640,7 @@ type issue_comment_event = {
   issue: issue;
   comment: issue_comment;
 } <ocaml field_prefix="issue_comment_event_">
-  <json adapter.ocaml="Github_json.Adapter.Action">
+  <json adapter.ocaml="Github_json.Adapter.Changes">
 
 type issues_action = [
   | Assigned <json name="assigned">
@@ -660,7 +660,7 @@ type issues_event = {
   ?assignee: user_info option;
   ?label: label option;
 } <ocaml field_prefix="issues_event_">
-  <json adapter.ocaml="Github_json.Adapter.Action">
+  <json adapter.ocaml="Github_json.Adapter.Changes">
 
 type member_action = [
   | Added <json name="added">
@@ -712,7 +712,7 @@ type pull_request_event = {
   number: int;
   pull_request: pull;
 } <ocaml field_prefix="pull_request_event_">
-  <json adapter.ocaml="Github_json.Adapter.Action">
+  <json adapter.ocaml="Github_json.Adapter.Changes">
 
 type pull_request_review_comment_action = [
   | Created <json name="created">
@@ -734,7 +734,7 @@ type pull_request_review_comment_event = {
   pull_request: pull;
   comment: pull_request_review_comment;
 } <ocaml field_prefix="pull_request_review_comment_event_">
-  <json adapter.ocaml="Github_json.Adapter.Action">
+  <json adapter.ocaml="Github_json.Adapter.Changes">
 
 type push_event_author = {
   name: string;

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -538,11 +538,13 @@ type create_event = {
   ?description: string option;
   (* pusher_type *)
 } <ocaml field_prefix="create_event_">
+  <json adapter.ocaml="Github_json.Adapter.Ref_type">
 
 type delete_event = {
   ref <json tag_field="ref_type">: ref;
   (* pusher_type *)
 } <ocaml field_prefix="delete_event_">
+  <json adapter.ocaml="Github_json.Adapter.Ref_type">
 
 type fork_event = {
   forkee: repository;
@@ -638,6 +640,7 @@ type issue_comment_event = {
   issue: issue;
   comment: issue_comment;
 } <ocaml field_prefix="issue_comment_event_">
+  <json adapter.ocaml="Github_json.Adapter.Action">
 
 type issues_action = [
   | Assigned <json name="assigned">
@@ -657,6 +660,7 @@ type issues_event = {
   ?assignee: user_info option;
   ?label: label option;
 } <ocaml field_prefix="issues_event_">
+  <json adapter.ocaml="Github_json.Adapter.Action">
 
 type member_action = [
   | Added <json name="added">
@@ -708,6 +712,7 @@ type pull_request_event = {
   number: int;
   pull_request: pull;
 } <ocaml field_prefix="pull_request_event_">
+  <json adapter.ocaml="Github_json.Adapter.Action">
 
 type pull_request_review_comment_action = [
   | Created <json name="created">
@@ -729,6 +734,7 @@ type pull_request_review_comment_event = {
   pull_request: pull;
   comment: pull_request_review_comment;
 } <ocaml field_prefix="pull_request_review_comment_event_">
+  <json adapter.ocaml="Github_json.Adapter.Action">
 
 type push_event_author = {
   name: string;
@@ -940,6 +946,7 @@ type event = {
   repo: repo;
   id: int <ocaml repr="int64">;
 } <ocaml field_prefix="event_">
+  <json adapter.ocaml="Github_json.Adapter.Payload">
 
 type events = event list
 
@@ -1013,6 +1020,7 @@ type hook = {
   config <json tag_field="name">: hook_config;
   id: int <ocaml repr="int64">;
 } <ocaml field_prefix="hook_">
+  <json adapter.ocaml="Github_json.Adapter.Config">
 
 type hooks = hook list
 
@@ -1021,12 +1029,14 @@ type new_hook = {
   events: event_type list;
   active: bool;
 } <ocaml field_prefix="new_hook_">
+  <json adapter.ocaml="Github_json.Adapter.Config">
 
 type update_hook = {
   config <json tag_field="name">: hook_config;
   ?events: event_type list option;
   active: bool;
 } <ocaml field_prefix="update_hook_">
+  <json adapter.ocaml="Github_json.Adapter.Config">
 
 type status_state = [
   | Pending <json name="pending">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -533,7 +533,7 @@ type ref = [
 ]
 
 type create_event = {
-  ref <json tag_field="ref_type">: ref;
+  ref: ref;
   master_branch: string;
   ?description: string option;
   (* pusher_type *)
@@ -541,7 +541,7 @@ type create_event = {
   <json adapter.ocaml="Github_json.Adapter.Ref">
 
 type delete_event = {
-  ref <json tag_field="ref_type">: ref;
+  ref: ref;
   (* pusher_type *)
 } <ocaml field_prefix="delete_event_">
   <json adapter.ocaml="Github_json.Adapter.Ref">
@@ -636,7 +636,7 @@ type issue_comment_action = [
 ]
 
 type issue_comment_event = {
-  action <json name="changes" tag_field="action">: issue_comment_action;
+  action <json name="changes">: issue_comment_action;
   issue: issue;
   comment: issue_comment;
 } <ocaml field_prefix="issue_comment_event_">
@@ -655,7 +655,7 @@ type issues_action = [
 ]
 
 type issues_event = {
-  action <json name="changes" tag_field="action">: issues_action;
+  action <json name="changes">: issues_action;
   issue: issue;
   ?assignee: user_info option;
   ?label: label option;
@@ -708,7 +708,7 @@ type pull_request_action = [
 ]
 
 type pull_request_event = {
-  action <json name="changes" tag_field="action">: pull_request_action;
+  action <json name="changes">: pull_request_action;
   number: int;
   pull_request: pull;
 } <ocaml field_prefix="pull_request_event_">
@@ -730,7 +730,7 @@ type pull_request_review_comment = {
 } <ocaml field_prefix="pull_request_review_comment_">
 
 type pull_request_review_comment_event = {
-  action <json name="changes" tag_field="action">: pull_request_review_comment_action;
+  action <json name="changes">: pull_request_review_comment_action;
   pull_request: pull;
   comment: pull_request_review_comment;
 } <ocaml field_prefix="pull_request_review_comment_event_">
@@ -941,7 +941,7 @@ type event_constr = [
 
 type event = {
   public: bool;
-  payload <json tag_field="type">: event_constr;
+  payload: event_constr;
   actor: user;
   ?org: org option;
   created_at: string;
@@ -1021,7 +1021,7 @@ type hook = {
   created_at: string;
   events: event_type list;
   active: bool;
-  config <json tag_field="name">: hook_config;
+  config: hook_config;
   id: int <ocaml repr="int64">;
 } <ocaml field_prefix="hook_">
   <json adapter.ocaml="Github_json.Adapter.Hook">
@@ -1029,14 +1029,14 @@ type hook = {
 type hooks = hook list
 
 type new_hook = {
-  config <json tag_field="name">: hook_config;
+  config: hook_config;
   events: event_type list;
   active: bool;
 } <ocaml field_prefix="new_hook_">
   <json adapter.ocaml="Github_json.Adapter.Hook">
 
 type update_hook = {
-  config <json tag_field="name">: hook_config;
+  config: hook_config;
   ?events: event_type list option;
   active: bool;
 } <ocaml field_prefix="update_hook_">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -632,7 +632,7 @@ type issue_comment_action = [
   | Created <json name="created">
   | Edited <json name="edited"> of body_changes
   | Deleted <json name="deleted">
-  | Unknown <json untyped> of (string * json option)
+  | Unknown of (string * json nullable)
 ]
 
 type issue_comment_event = {
@@ -640,7 +640,7 @@ type issue_comment_event = {
   issue: issue;
   comment: issue_comment;
 } <ocaml field_prefix="issue_comment_event_">
-  <json adapter.ocaml="Github_json.Adapter.Changes">
+  <json adapter.ocaml="Github_json.Adapter.Issue_comment_event">
 
 type issues_action = [
   | Assigned <json name="assigned">
@@ -651,7 +651,7 @@ type issues_action = [
   | Edited <json name="edited"> of ticket_changes
   | Closed <json name="closed">
   | Reopened <json name="reopened">
-  | Unknown <json untyped> of (string * json option)
+  | Unknown of (string * json nullable)
 ]
 
 type issues_event = {
@@ -660,7 +660,7 @@ type issues_event = {
   ?assignee: user_info option;
   ?label: label option;
 } <ocaml field_prefix="issues_event_">
-  <json adapter.ocaml="Github_json.Adapter.Changes">
+  <json adapter.ocaml="Github_json.Adapter.Issues_event">
 
 type member_action = [
   | Added <json name="added">
@@ -704,7 +704,7 @@ type pull_request_action = [
   | Closed <json name="closed">
   | Reopened <json name="reopened">
   | Synchronize <json name="synchronize">
-  | Unknown <json untyped> of (string * json option)
+  | Unknown of (string * json nullable)
 ]
 
 type pull_request_event = {
@@ -712,13 +712,13 @@ type pull_request_event = {
   number: int;
   pull_request: pull;
 } <ocaml field_prefix="pull_request_event_">
-  <json adapter.ocaml="Github_json.Adapter.Changes">
+  <json adapter.ocaml="Github_json.Adapter.Pull_request_event">
 
 type pull_request_review_comment_action = [
   | Created <json name="created">
   | Edited <json name="edited"> of body_changes
   | Deleted <json name="deleted">
-  | Unknown <json untyped> of (string * json option)
+  | Unknown of (string * json nullable)
 ]
 
 type pull_request_review_comment = {
@@ -734,7 +734,7 @@ type pull_request_review_comment_event = {
   pull_request: pull;
   comment: pull_request_review_comment;
 } <ocaml field_prefix="pull_request_review_comment_event_">
-  <json adapter.ocaml="Github_json.Adapter.Changes">
+  <json adapter.ocaml="Github_json.Adapter.Pull_request_review_comment_event">
 
 type push_event_author = {
   name: string;
@@ -934,7 +934,9 @@ type event_constr = [
   | Status <json name="StatusEvent"> of status_event
   (*| TeamAdd <json name="team_add"> of team_add_event*)
   | Watch <json name="WatchEvent"> of watch_event
-  | Unknown <json untyped> of (string * json option)
+
+  (* Catch-all *)
+  | Unknown of (string * json nullable)
 ]
 
 type event = {
@@ -946,7 +948,7 @@ type event = {
   repo: repo;
   id: int <ocaml repr="int64">;
 } <ocaml field_prefix="event_">
-  <json adapter.ocaml="Github_json.Adapter.Payload">
+  <json adapter.ocaml="Github_json.Adapter.Event">
 
 type events = event list
 
@@ -980,7 +982,9 @@ type event_hook_constr = [
   | Status <json name="StatusEvent"> of status_event
   (*| TeamAdd <json name="team_add"> of team_add_event*)
   | Watch <json name="WatchEvent"> of watch_event
-  | Unknown <json untyped> of (string * json option)
+
+  (* Catch-all for unsupported event types *)
+  | Unknown of (string * json nullable)
 ]
 
 type event_hook_metadata = {
@@ -1008,8 +1012,8 @@ type json <ocaml module="Yojson.Safe"> = abstract
 
 type hook_config = [
   | Web <json name="web"> of web_hook_config
-  | Unknown of string
-] <json open_enum>
+  | Unknown of (string * json nullable)
+]
 
 type hook = {
   url: string;
@@ -1020,7 +1024,7 @@ type hook = {
   config <json tag_field="name">: hook_config;
   id: int <ocaml repr="int64">;
 } <ocaml field_prefix="hook_">
-  <json adapter.ocaml="Github_json.Adapter.Config">
+  <json adapter.ocaml="Github_json.Adapter.Hook">
 
 type hooks = hook list
 
@@ -1029,14 +1033,14 @@ type new_hook = {
   events: event_type list;
   active: bool;
 } <ocaml field_prefix="new_hook_">
-  <json adapter.ocaml="Github_json.Adapter.Config">
+  <json adapter.ocaml="Github_json.Adapter.Hook">
 
 type update_hook = {
   config <json tag_field="name">: hook_config;
   ?events: event_type list option;
   active: bool;
 } <ocaml field_prefix="update_hook_">
-  <json adapter.ocaml="Github_json.Adapter.Config">
+  <json adapter.ocaml="Github_json.Adapter.Hook">
 
 type status_state = [
   | Pending <json name="pending">

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -46,8 +46,8 @@ type scope = [
   | Read_public_key <json name="read:public_key">
   | Write_public_key <json name="write:public_key">
   | Admin_public_key <json name="admin:public_key">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type app = {
   name: string;
@@ -101,8 +101,8 @@ type issue_sort = [
   | Created <json name="created">
   | Updated <json name="updated">
   | Comments <json name="comments">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type direction = [
   | Asc <json name="asc">
@@ -183,8 +183,8 @@ type team_permission = [
   | Pull <json name="pull">
   | Push <json name="push">
   | Admin <json name="admin">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type team_info = {
   permission: team_permission;
@@ -553,8 +553,8 @@ type fork_event = {
 type wiki_page_action = [
   | Created <json name="created">
   | Edited <json name="edited">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type wiki_page = {
   name <json name="page_name">: string;
@@ -586,8 +586,8 @@ type repo_issues_action = [
   | Unlocked <json name="unlocked">
   | Head_ref_deleted <json name="head_ref_deleted">
   | Head_ref_restored <json name="head_ref_restored">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown string
+] <json open_enum>
 
 type issue_rename = {
   from: string;
@@ -664,8 +664,8 @@ type issues_event = {
 
 type member_action = [
   | Added <json name="added">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type member_event = {
   action: member_action;
@@ -681,8 +681,8 @@ type page_build_status = [
   | Building <json name="building">
   | Built <json name="built">
   | Errored <json name="errored">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type page_build = {
   url: string;
@@ -783,8 +783,8 @@ type push_event_hook = {
 
 type release_action = [
   | Published <json name="published">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type release_event = {
   action: release_action;
@@ -796,8 +796,8 @@ type repository_action = [
   | Deleted <json name="deleted">
   | Publicized <json name="publicized">
   | Privatized <json name="privatized">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type repository_event = {
   action: repository_action;
@@ -844,8 +844,8 @@ type team_add_event = {
 
 type watch_action = [
   | Started <json name="started">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type watch_event = {
   action: watch_action;
@@ -901,8 +901,8 @@ type event_type = [
   | TeamAdd <json name="team_add">
   | Watch <json name="watch">
   | All <json name="*">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type event_constr = [
   | CommitComment <json name="CommitCommentEvent"> of commit_comment_event
@@ -1008,8 +1008,8 @@ type json <ocaml module="Yojson.Safe"> = abstract
 
 type hook_config = [
   | Web <json name="web"> of web_hook_config
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type hook = {
   url: string;
@@ -1043,8 +1043,8 @@ type status_state = [
   | Success <json name="success">
   | Failure <json name="failure">
   | Error <json name="error">
-  | Unknown <json untyped> of (string * json option)
-]
+  | Unknown of string
+] <json open_enum>
 
 type base_status = {
   url: string;

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -119,7 +119,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       | `Read_public_key -> "read:public_key"
       | `Write_public_key -> "write:public_key"
       | `Admin_public_key -> "admin:public_key"
-      | `Unknown (cons, _json) -> "unknown:"^cons
+      | `Unknown cons -> "unknown:"^cons
 
     let of_string x : Github_t.scope option =
       match x with
@@ -1205,7 +1205,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
         let uri = URI.org_hook_test ~org ~id in
         API.post ?token ~uri ~expected_code:`No_content (fun _b -> return ())
 
-      let parse_event ~constr ~payload () =
+      let parse_event ~constr ~payload () : Github_t.event_hook_constr =
         let parse_json = function
           | "" -> None
           | s -> Some (Yojson.Safe.from_string s)
@@ -1256,7 +1256,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
         | `Watch ->
           `Watch (Github_j.watch_event_of_string payload)
         | `All -> `Unknown ("*", parse_json payload)
-        | `Unknown (cons,_) -> `Unknown (cons, parse_json payload)
+        | `Unknown cons -> `Unknown (cons, parse_json payload)
 
       let parse_event_metadata ~payload () =
         Github_j.event_hook_metadata_of_string payload

--- a/lib/github_json.ml
+++ b/lib/github_json.ml
@@ -7,24 +7,110 @@ module Adapter = struct
     Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
       let type_field_name = "ref_type"
       let value_field_name = "ref"
-    end)
-
-  module Changes =
-    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
-      let type_field_name = "action"
-      let value_field_name = "changes"
+      let known_tags = None
     end)
 
   module Payload =
     Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
       let type_field_name = "type"
       let value_field_name = "payload"
+      let known_tags = None
     end)
 
-  module Config =
+  module Issue_comment_event =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "action"
+      let value_field_name = "changes"
+      let known_tags =
+        Some (["created"; "edited"; "deleted"], "Unknown")
+    end)
+
+  module Issues_event =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "action"
+      let value_field_name = "changes"
+      let known_tags =
+        Some (
+          [
+            "assigned";
+            "unassigned";
+            "labeled";
+            "unlabeled";
+            "opened";
+            "edited";
+            "closed";
+            "reopened";
+          ],
+          "Unknown"
+        )
+    end)
+
+  module Pull_request_event =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "action"
+      let value_field_name = "changes"
+      let known_tags =
+        Some (
+          [
+            "assigned";
+            "unassigned";
+            "labeled";
+            "unlabeled";
+            "opened";
+            "edited";
+            "closed";
+            "reopened";
+            "synchronize";
+          ],
+          "Unknown"
+        )
+    end)
+
+  module Pull_request_review_comment_event =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "action"
+      let value_field_name = "changes"
+      let known_tags =
+        Some (["created"; "edited"; "deleted"], "Unknown")
+    end)
+
+  module Event =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "type"
+      let value_field_name = "payload"
+      let known_tags =
+        Some (
+          [
+            "CommitCommentEvent";
+            "CreateEvent";
+            "DeleteEvent";
+            "DownloadEvent";
+            "FollowEvent";
+            "ForkEvent";
+            "ForkApplyEvent";
+            "GistEvent";
+            "GollumEvent";
+            "IssueCommentEvent";
+            "IssuesEvent";
+            "MemberEvent";
+            "PublicEvent";
+            "PullRequestEvent";
+            "PullRequestReviewCommentEvent";
+            "PushEvent";
+            "ReleaseEvent";
+            "RepositoryEvent";
+            "StatusEvent";
+            "WatchEvent";
+          ],
+          "Unknown"
+        )
+    end)
+
+  module Hook =
     Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
       let type_field_name = "name"
       let value_field_name = "config"
+      let known_tags = Some (["web"], "Unknown")
     end)
 end
 

--- a/lib/github_json.ml
+++ b/lib/github_json.ml
@@ -1,0 +1,30 @@
+(*
+   Adapters used by atdgen to turn Github's representation of variants
+   into an ATD-compatible representation.
+*)
+module Adapter = struct
+  module Ref =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "ref_type"
+      let value_field_name = "ref"
+    end)
+
+  module Changes =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "action"
+      let value_field_name = "changes"
+    end)
+
+  module Payload =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "type"
+      let value_field_name = "payload"
+    end)
+
+  module Config =
+    Atdgen_runtime.Util.Json.Adapter.Type_and_value_fields.Make (struct
+      let type_field_name = "name"
+      let value_field_name = "config"
+    end)
+end
+

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -24,5 +24,5 @@
    |#
   (flags (:standard -principal -strict-sequence -g -safe-string
                     -w "A-E-41-42-44-48" -w "-27-32"))
-  (modules (github_s github_core github_j github_t))
+  (modules (github_s github_core github_json github_j github_t))
   (libraries (cohttp uri cohttp-lwt yojson atdgen))))


### PR DESCRIPTION
I removed some features from atdgen (`tag_field`, `untyped`) that were specific to how Github represents variants. I replaced them with a more generic mechanism, which simplifies atdgen's codebase and is more flexible. This new mechanism is called "json adapters". The idea is that when the structure of some json data doesn't match atdgen's conventions, the user can write a pair of functions that transform the json AST locally into a suitable form.

This branch should have everything it needs to work with json adapters (https://github.com/mjambon/atd/pull/72). `make test` was suspiciously short; what's a good way for me to test that it's all working?