### PR TITLE
Add the API /user/orgs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
  global:
    - PINS="github:. github-unix:. github-jsoo:."
    - DEPOPTS="github-unix github-jsoo"
+   - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.07 PACKAGE="github" REVDEPS=true
    - DISTRO=debian-stable OCAML_VERSION=4.06 PACKAGE="github-unix" REVDEPS=true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## dev
+
+- Switch to dune-release instead of topkg (@avsm)
+- Do not use deprecated `Yojson.Safe.json` (@avsm)
+
 ## 4.0.0 (2018-12-11)
 
 - Port to latest Atd 2.0.0 interfaces (#218 by @mjambon and @avsm)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
-## dev
+## 4.1.0 (2019-06-03)
 
-- Switch to dune-release instead of topkg (@avsm)
-- Do not use deprecated `Yojson.Safe.json` (@avsm)
-- Support lambda-term/zed 2.0.0 interfaces (@avsm)
+- Add the interface for `/user/orgs` (#222 @Aaylor)
+- Switch to dune-release instead of topkg (#224 @avsm)
+- Do not use deprecated `Yojson.Safe.json` (#224 @avsm)
+- Support lambda-term/zed 2.0.0 interfaces (#224 @avsm)
 
 ## 4.0.0 (2018-12-11)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Switch to dune-release instead of topkg (@avsm)
 - Do not use deprecated `Yojson.Safe.json` (@avsm)
+- Support lambda-term/zed 2.0.0 interfaces (@avsm)
 
 ## 4.0.0 (2018-12-11)
 

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,3 @@ uninstall:
 clean:
 	rm -rf _build *.install
 
-REPO=../../mirage/opam-repository
-PACKAGES=$(REPO)/packages
-# until we have https://github.com/ocaml/opam-publish/issues/38
-pkg-%:
-	topkg opam pkg -n $*
-	mkdir -p $(PACKAGES)/$*
-	cp -r _build/$*.* $(PACKAGES)/$*/
-	cd $(PACKAGES) && git add $*
-
-PKGS=$(basename $(wildcard *.opam))
-opam-pkg:
-	$(MAKE) $(PKGS:%=pkg-%)
-
-

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [List teams](https://developer.github.com/v3/orgs/teams/#list-teams)
  * [Get team](https://developer.github.com/v3/orgs/teams/#get-team)
  * [List team repos](https://developer.github.com/v3/orgs/teams/#list-team-repos)
+ * [List your organizations](https://developer.github.com/v3/orgs/#list-your-organizations)
  * [List (public) user organizations](https://developer.github.com/v3/orgs/#list-user-organizations)
  * [Webhooks](https://developer.github.com/v3/orgs/hooks/)
 

--- a/gist/gist.ml
+++ b/gist/gist.ml
@@ -37,7 +37,7 @@ module Passwd = struct
 
   class read_password term = object(self)
     inherit LTerm_read_line.read_password () as super
-    inherit [Zed_utf8.t] LTerm_read_line.term term
+    inherit [Zed_string.t] LTerm_read_line.term term
 
     method! send_action = function
       | LTerm_read_line.Break ->
@@ -46,7 +46,7 @@ module Passwd = struct
       | action ->
           super#send_action action
     initializer
-      self#set_prompt (S.const (LTerm_text.of_string "Enter Github password: "))
+      self#set_prompt (S.const (LTerm_text.of_utf8 "Enter Github password: "))
   end
 
   let get =
@@ -56,7 +56,7 @@ module Passwd = struct
       Lazy.force LTerm.stdout >>= fun term ->
       (new read_password term)#run >>= fun p ->
       print_endline "";
-      return p
+      return (Zed_string.to_utf8 p)
     |p -> return p
 end
 

--- a/gist/gist.ml
+++ b/gist/gist.ml
@@ -28,7 +28,7 @@ module M = Github.Monad
 
 let gist_version = "0.1.0"
 
-let very_pretty_json s = Json.to_string (Yojson.Safe.from_string s :> Yojson.json)
+let very_pretty_json s = Json.to_string (Yojson.Safe.from_string s :> Yojson.t)
 let quite_pretty_json s = Yojson.Safe.pretty_to_string (Yojson.Safe.from_string s)
 let pretty_json pretty = if pretty then very_pretty_json else quite_pretty_json
 

--- a/gist/json.ml
+++ b/gist/json.ml
@@ -23,7 +23,7 @@ let tuple = { list with
 let variant = { list with
 		  space_before_closing = false; }
 
-let rec format std (x : Yojson.json) =
+let rec format std (x : Yojson.t) =
   match x with
       `Null -> Atom ("null", atom)
     | `Bool x -> Atom ((if x then "true" else "false"), atom)
@@ -75,7 +75,7 @@ let format ?(std = false) x =
     Yojson.json_error
       "Root is not an object or array as requested by the JSON standard"
   else
-    format std (x :> Yojson.json)
+    format std (x :> Yojson.t)
 
 let to_string ?std x =
   Easy_format.Pretty.to_string (format ?std x)

--- a/github-unix.opam
+++ b/github-unix.opam
@@ -26,7 +26,7 @@ depends: [
   "github" {=version}
   "cohttp-lwt-unix" {>="1.2.0"}
   "stringext"
-  "lambda-term" {>="2.0.0"}
+  "lambda-term" {>="2.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/github-unix.opam
+++ b/github-unix.opam
@@ -22,11 +22,11 @@ doc: "https://mirage.github.io/ocaml-github/"
 bug-reports: "https://github.com/mirage/ocaml-github/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
-  "github"
-  "cohttp-lwt-unix"
+  "dune" 
+  "github" {=version}
+  "cohttp-lwt-unix" {>="1.2.0"}
   "stringext"
-  "lambda-term"
+  "lambda-term" {>="2.0.0"}
   "cmdliner" {>= "0.9.8"}
   "base-unix"
 ]

--- a/github-unix.opam
+++ b/github-unix.opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" 
   "github" {=version}
-  "cohttp-lwt-unix" {>="1.2.0"}
+  "cohttp-lwt-unix"
   "stringext"
   "lambda-term" {>="2.0"}
   "cmdliner" {>= "0.9.8"}

--- a/github.opam
+++ b/github.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-lwt" {>= "0.99"}
   "lwt" {>= "2.4.4"}
   "atdgen" {>= "2.0.0"}
-  "yojson" {>= "1.2.0"}
+  "yojson" {>= "1.6.0"}
   "stringext"
 ]
 build: [

--- a/github.opam
+++ b/github.opam
@@ -24,7 +24,7 @@ doc: "https://mirage.github.io/ocaml-github/"
 bug-reports: "https://github.com/mirage/ocaml-github/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "uri" {>= "1.9.0"}
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt" {>= "0.99"}

--- a/init_config.sh
+++ b/init_config.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-if [ ! -e ./lib_test/config.ml ]; then
-  cp ./lib_test/config.ml.in ./lib_test/config.ml
-fi

--- a/jar/passwd.ml
+++ b/jar/passwd.ml
@@ -19,7 +19,7 @@ open Lwt_react
 
 class read_password term = object(self)
   inherit LTerm_read_line.read_password () as super
-  inherit [Zed_utf8.t] LTerm_read_line.term term
+  inherit [Zed_string.t] LTerm_read_line.term term
 
   method! send_action = function
     | LTerm_read_line.Break ->
@@ -28,7 +28,7 @@ class read_password term = object(self)
     | action ->
         super#send_action action
   initializer
-    self#set_prompt (S.const (LTerm_text.of_string "Enter Github password: "))
+    self#set_prompt (S.const (LTerm_text.of_utf8 "Enter Github password: "))
 end
 
 let get =
@@ -38,5 +38,5 @@ let get =
     Lazy.force LTerm.stdout >>= fun term ->
     (new read_password term)#run >>= fun p ->
     print_endline "";
-    return p
+    return (Zed_string.to_utf8 p)
   |p -> return p

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -632,7 +632,7 @@ type issue_comment_action = [
   | Created <json name="created">
   | Edited <json name="edited"> of body_changes
   | Deleted <json name="deleted">
-  | Unknown of (string * json nullable)
+  | Unknown of (string * t nullable)
 ]
 
 type issue_comment_event = {
@@ -651,7 +651,7 @@ type issues_action = [
   | Edited <json name="edited"> of ticket_changes
   | Closed <json name="closed">
   | Reopened <json name="reopened">
-  | Unknown of (string * json nullable)
+  | Unknown of (string * t nullable)
 ]
 
 type issues_event = {
@@ -704,7 +704,7 @@ type pull_request_action = [
   | Closed <json name="closed">
   | Reopened <json name="reopened">
   | Synchronize <json name="synchronize">
-  | Unknown of (string * json nullable)
+  | Unknown of (string * t nullable)
 ]
 
 type pull_request_event = {
@@ -718,7 +718,7 @@ type pull_request_review_comment_action = [
   | Created <json name="created">
   | Edited <json name="edited"> of body_changes
   | Deleted <json name="deleted">
-  | Unknown of (string * json nullable)
+  | Unknown of (string * t nullable)
 ]
 
 type pull_request_review_comment = {
@@ -936,7 +936,7 @@ type event_constr = [
   | Watch <json name="WatchEvent"> of watch_event
 
   (* Catch-all *)
-  | Unknown of (string * json nullable)
+  | Unknown of (string * t nullable)
 ]
 
 type event = {
@@ -984,7 +984,7 @@ type event_hook_constr = [
   | Watch <json name="WatchEvent"> of watch_event
 
   (* Catch-all for unsupported event types *)
-  | Unknown of (string * json nullable)
+  | Unknown of (string * t nullable)
 ]
 
 type event_hook_metadata = {
@@ -1008,11 +1008,11 @@ type web_hook_config = {
   ?secret: string option;
 } <ocaml field_prefix="web_hook_config_">
 
-type json <ocaml module="Yojson.Safe"> = abstract
+type t <ocaml module="Yojson.Safe"> = abstract
 
 type hook_config = [
   | Web <json name="web"> of web_hook_config
-  | Unknown of (string * json nullable)
+  | Unknown of (string * t nullable)
 ]
 
 type hook = {

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -212,6 +212,9 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
     let repos =
       Uri.of_string (Printf.sprintf "%s/user/repos" api)
 
+    let orgs =
+      Uri.of_string (Printf.sprintf "%s/user/orgs" api)
+
     let repo ~user ~repo =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s" api user repo)
 
@@ -1270,6 +1273,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
 
     let user_orgs ?token ~user () =
       let uri = URI.user_orgs ~user in
+      API.get_stream ?token ~uri (fun b -> return (orgs_of_string b))
+
+    let current_user_orgs ?token () =
+      let uri = URI.orgs in
       API.get_stream ?token ~uri (fun b -> return (orgs_of_string b))
   end
 

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -448,7 +448,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
     type error =
       | Generic of (C.Response.t * string)
       | Semantic of C.Code.status_code * Github_t.message
-      | Bad_response of exn * [ `None | `Json of Yojson.Basic.json | `Raw of string ]
+      | Bad_response of exn * [ `None | `Json of Yojson.Basic.t | `Raw of string ]
     type request = {
       meth: C.Code.meth; uri: Uri.t;
       headers: C.Header.t; body: string;

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -644,6 +644,13 @@ module type Github = sig
     (** [user_orgs ~user ()] is a stream of the organizations
          to which the user [user] belongs. *)
 
+    val current_user_orgs:
+      ?token:Token.t ->
+      unit -> Github_t.org Stream.t
+    (** [current_user ()] is a stream of the organizations to which
+        the user linked to current token belongs, and for which the user
+        granted access to the organizations to the current token. *)
+
     (** The [Hook] module provides access to GitHub's
         {{:https://developer.github.com/v3/orgs/hooks/}organization
         webhooks API} which lets you manage an organization's

--- a/lib_test/current_user_orgs.ml
+++ b/lib_test/current_user_orgs.ml
@@ -1,0 +1,17 @@
+open Github_t
+
+let token = Config.access_token
+
+let t = Github.(Monad.(run (
+    let orgs = Organization.current_user_orgs ~token () in
+    Stream.next orgs
+    >>= function
+    | None -> Printf.eprintf "no orgs for current user\n"; exit 1
+    | Some (first_org, _) ->
+      Printf.eprintf "org %Ld: %s\n%!" first_org.org_id first_org.org_login;
+      return ()
+)))
+
+;;
+
+Lwt_main.run t

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -4,6 +4,7 @@
                     -w "A-E-41-42-44-48"))
   (names 
    current_user
+   current_user_orgs
     rwo
     get_token
     repo_info
@@ -15,6 +16,7 @@
  (name DEFAULT)
   (deps
    current_user.exe
+   current_user_orgs.exe
     rwo.exe
     get_token.exe
     repo_info.exe

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,2 +1,0 @@
-#use "topfind"
-#require "topkg-jbuilder.auto"


### PR DESCRIPTION
In order to list the current user organizations, and for which the user has granted the OAuth application the acces to the organizations, we must use the API [/user/orgs](https://developer.github.com/v3/orgs/#list-your-organizations).

It is different from `/users/:username/orgs`: it returns only public organizations, which the OAuth application (via the token) may not have been granted access.