### PR TITLE
Add repositories permissions datatype

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -388,6 +388,12 @@ type new_repo = {
   ?license_template : string option;
 } <ocaml field_prefix="new_repo_">
 
+type repository_permissions = {
+  admin: bool;
+  push: bool;
+  pull: bool
+} <ocaml field_prefix="repository_permissions_">
+
 type repository = {
   owner: user;
   full_name: string;
@@ -416,6 +422,7 @@ type repository = {
   has_wiki: bool;
   has_downloads: bool;
   has_pages: bool;
+  ?permissions: repository_permissions option;
   inherit repo
 } <ocaml field_prefix="repository_">
 

--- a/lib_test/repo_info.ml
+++ b/lib_test/repo_info.ml
@@ -14,6 +14,14 @@ let t =
       | None -> ""
     in
     eprintf "repo %s\n" descr;
+    begin match info.repository_permissions with
+      | Some permissions ->
+        eprintf "permissions admin(%B) push(%B) pull(%B)\n"
+          permissions.repository_permissions_admin
+          permissions.repository_permissions_push
+          permissions.repository_permissions_pull
+      | None -> ()
+    end;
     let branches = Repo.branches ~token ~user:"ocaml" ~repo:"opam" () in
     Stream.to_list branches
     >>= fun branches ->


### PR DESCRIPTION
When getting the description of the repository, the JSON object `permissions` may appear.
An example is in the description of the API to [get information about a specific repository](https://developer.github.com/v3/repos/#get).

After multiple tests, this object appears only when the requests is authenticated via the token; this is why the field is optional.