### PR TITLE
Reintroduce user type

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -109,10 +109,16 @@ type direction = [
   | Desc <json name="desc">
 ]
 
+type user_type = [
+  | User <json name="User">
+  | Org <json name="Organization">
+]
+
 type org = {
   login: string;
   id: int <ocaml repr="int64">;
   url: string;
+  ty <json name="type">: user_type;
   ?avatar_url: string option;
 } <ocaml field_prefix="org_">
 
@@ -151,7 +157,6 @@ type user_info = {
   html_url: string;
   created_at: string;
   updated_at: string;
-  (*ty <json name="type">: user_type;*)
   inherit linked_user
 } <ocaml field_prefix="user_info_">
 

--- a/lib_test/current_user_orgs.ml
+++ b/lib_test/current_user_orgs.ml
@@ -9,6 +9,7 @@ let t = Github.(Monad.(run (
     | None -> Printf.eprintf "no orgs for current user\n"; exit 1
     | Some (first_org, _) ->
       Printf.eprintf "org %Ld: %s\n%!" first_org.org_id first_org.org_login;
+      assert (first_org.org_ty = `Org);
       return ()
 )))
 


### PR DESCRIPTION
## Problem

TL;DR: There is no simple way to know if a "user" is an `Organization` or a simple `User` from the GitHub POV.

I've seen that the type `user_type` was removed, in favor of splitting `user` in two distinct part: `user` and `org`.

When we do not have a complete control about the GitHub username (coming from a user input for example), it becomes hard to know if we are talking about an organization or a user; the only way I found would be to call `/orgs/:user` first: if it returns 404, then it may be a user, otherwise it is an organization.

As an example, if we want to get information of a specific repository (for the example, let's say the `ocaml` repository from the `ocaml` organization), there is a need of extra works to know if the repository owner is an organization or a user.
 

## Chosen solution

Reintroduce the type `user_type`, and adding them to both `user` and `org` type; this is the simplest solution to ensure the backward compatibility with older versions.

## Other solution

Having a type looking like
```
type github_user =
  | User of user_info
  | Org of organization
```

And everywhere we may have one or another (repository owner, fetching a specific user, ...) using this type. Otherwise using the concerned type (`organization` when listing a user organization for example).


(Sorry, this small PR comes right after you released the last version :/)