### PR TITLE
Deprecated authentication method

### DIFF
--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -262,7 +262,12 @@ module type Github = sig
       tokens} and
       {{:https://help.github.com/articles/creating-an-access-token-for-command-line-use/}"personal
       tokens"}.
+
+      Note: the OAuth Authorizations API has been deprecated by GitHub.
+
       @see <https://developer.github.com/v3/oauth_authorizations/> OAuth Authorizations API
+      @see <https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#deprecating-and-adding-endpoints-for-the-oauth-authorizations-and-oauth-applications-apis>
+      for the OAuth Authorizations deprecation.
   *)
   module Token : sig
     type t


### PR DESCRIPTION
Since November 2019, authenticated request using query parameters has been deprecated by GitHub (see their [blog post](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters)); and they are starting to be more aggresive about it recently (receiving mails about the deprecated usage of `access_token` often).

This pull-request:
- Updates the authentication method using the `Authorization` HTTP header.
- Add a note about the OAuth Authorizations API deprecation for the `Token` module.