### PR TITLE
Fix PR#228

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -118,14 +118,15 @@ type org = {
   login: string;
   id: int <ocaml repr="int64">;
   url: string;
-  ty <json name="type">: user_type;
+  ~ty <json name="type"> <ocaml default="`Org">: user_type;
   ?avatar_url: string option;
 } <ocaml field_prefix="org_">
 
 type orgs = org list
 
 type user = {
-  inherit org
+  inherit org;
+  ~ty <json name="type"> <ocaml default="`User">: user_type;
 } <ocaml field_prefix="user_">
 
 type linked_user = {

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -8,7 +8,8 @@
     rwo
     get_token
     repo_info
-    contributors))
+    contributors
+    user_type))
 
 (rule (copy config.ml.in config.ml))
 
@@ -20,4 +21,5 @@
     rwo.exe
     get_token.exe
     repo_info.exe
-    contributors.exe))
+    contributors.exe
+    user_type.exe))

--- a/lib_test/user_type.ml
+++ b/lib_test/user_type.ml
@@ -1,0 +1,57 @@
+let token = Config.access_token
+
+let test_current_user =
+  (* Test if the current user, associated with the access token, is correctly
+     flagged as [`User]. *)
+  let current_user =
+    Lwt_main.run begin
+      Github.(Monad.(run (User.current_info ~token () >|= Response.value)))
+    end
+  in
+  assert (current_user.Github_t.user_info_ty = `User);
+  Format.printf "Check current user: OK.@."
+
+let test_current_user_first_org =
+  (* Test if the current user, associated with the access token, first
+     organization in the list is correctly flagged as [`Org]. *)
+  let org =
+    Lwt_main.run begin
+      Github.(Monad.(run begin
+          let orgs = Organization.current_user_orgs ~token () in
+          Stream.next orgs >>= function
+          | None ->
+            Printf.eprintf "No organizations for the current user.\n";
+            exit 1
+          | Some (first_org, _) ->
+            return first_org
+        end))
+    end
+  in
+  assert (org.Github_t.org_ty = `Org);
+  Format.printf "Check current user first org: OK.@."
+
+let test_ocaml_organization =
+  (* Test if the OCaml organization (using the [/user/...] API) is correctly
+     flagged as [`Org]. *)
+  let ocaml_user =
+    Lwt_main.run begin
+      Github.(Monad.(run begin
+          User.info ~token ~user:"ocaml" () >|= Response.value
+        end))
+    end
+  in
+  assert (ocaml_user.Github_t.user_info_ty = `Org);
+  Format.printf "Check OCaml org: OK.@."
+
+let test_ocaml_repository =
+  (* Test if the owner of the [opam] repository (using the [/repos/...] APIS) is
+     correctly flag as [`Org]. *)
+  let opam_repository =
+    Lwt_main.run begin
+      Github.(Monad.(run begin
+          Repo.info ~token ~user:"ocaml" ~repo:"opam" () >|= Response.value
+        end))
+    end
+  in
+  assert Github_t.(opam_repository.repository_owner.user_ty = `Org);
+  Format.printf "Check OCaml repo: OK.@."


### PR DESCRIPTION
It seems that I did not tested well the last PR#228 (I may have miss to pin my changes...), introducing a regression when parsing the payload for the API function `/user/orgs` (where the field `type` is not present...).

This PR add a default value (`Org` for organizations, and `User` for users) when the field is not present in the payload. I do not know if it is the best idea, but it seems reasonable to always add the user type (instead of making it optional).

I apologize for introduced mistake...