### PR TITLE
Do not print errors on stderr

### DIFF
--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -529,8 +529,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       | _, Request (_,_) -> Lwt.fail (Failure "Impossible: can't run unapplied request")
       | _, Response r -> Lwt.return r
       | _, Err (Semantic (status,msg)) -> Lwt.(fail (Message (status,msg)))
-      | _, Err e -> Lwt.(error_to_string e >>= fun err ->
-                           Printf.eprintf "%s%!" err; fail (Failure err))
+      | _, Err e -> Lwt.(error_to_string e >>= fun err -> fail (Failure err))
 
     let (>>=) m f = bind f m
     let (>|=) m f = map f m


### PR DESCRIPTION
When there is an error, `Monad.run` prints it to stderr in addition to returning it. So it is impossible to silently handle errors. This removes the eprintf call which is now the caller's responsibility.

Closes #233