### PR TITLE
Support the field `committer` in the type `git_commit`.

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -360,6 +360,7 @@ type tag = {
 type git_commit = {
   url: string;
   author: info;
+  committer: info;
   message: string;
 } <ocaml field_prefix="git_commit_">
 

--- a/lib_test/repo_info.ml
+++ b/lib_test/repo_info.ml
@@ -3,6 +3,8 @@ open Github_t
 
 let token = Config.access_token
 
+let opam_first_commit = "3656b4d1b03a8ae356cf82f7052f1976df8787be"
+
 let t =
   let open Github in
   let open Monad in
@@ -29,7 +31,15 @@ let t =
       eprintf "branch %s %s\n"
         b.repo_branch_name
         b.repo_branch_commit.repo_commit_sha
-    ) branches;
+      ) branches;
+    Repo.get_commit ~token ~user:"ocaml" ~repo:"opam" ~sha:opam_first_commit ()
+    >>~ fun commit ->
+    eprintf
+      "opam first commit author date: %s\n"
+      commit.commit_git.git_commit_author.info_date;
+    eprintf
+      "opam first commit committer date: %s\n"
+      commit.commit_git.git_commit_author.info_date;
     return ()
   )
 


### PR DESCRIPTION
Looking at the GitHub [API documentation](https://github.com/Aaylor/ocaml-github/pull/new/feat.support-committer-in-git-commit), the type `git_commit` (where the field is named `commit` in the GitHub documentation) should support the field `committer`, which have the same format as the field `author`. 