### PR TITLE
Add support for listing an organisation's repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Your Github application can now use it via the `Github_cookie_jar` module:
 ```ocaml
 # #require "github.unix";;
 # Github_cookie_jar.(init () |> Lwt_main.run |> get ~name:"rwo");;
-- : Github_t.auth option = 
+- : Github_t.auth option =
 Some
  {Github_t.auth_scopes = [`Public_repo];
   auth_token = "<token>";
@@ -244,13 +244,13 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * Most [Webhooks](https://developer.github.com/v3/repos/hooks/) endpoints
  * [Get contributors list with additions, deletions, and commit counts](https://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts)
  * [Collaborators](https://developer.github.com/v3/repos/collaborators/)
+ * [List organization
+   repositories](https://developer.github.com/v3/repos/#list-organization-repositories)
 
 *Not yet supported*:
 
  * [List your
    repositories](https://developer.github.com/v3/repos/#list-your-repositories)
- * [List organization
-   repositories](https://developer.github.com/v3/repos/#list-organization-repositories)
  * [List all public
    repositories](https://developer.github.com/v3/repos/#list-all-public-repositories)
  * [Edit](https://developer.github.com/v3/repos/#edit)

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -1286,6 +1286,12 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
     let current_user_orgs ?token () =
       let uri = URI.orgs in
       API.get_stream ?token ~uri (fun b -> return (orgs_of_string b))
+
+    let repositories ?token ~org () =
+      let uri = URI.org_repos ~org in
+      API.get_stream ?token ~uri (fun b ->
+          return (repositories_of_string b)
+        )
   end
 
   module Team = struct

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -656,6 +656,14 @@ module type Github = sig
         the user linked to current token belongs, and for which the user
         granted access to the organizations to the current token. *)
 
+    val repositories:
+      ?token:Token.t ->
+      org:string  ->
+      unit ->
+      Github_t.repository Stream.t
+    (** [repositories ~org ()] is a stream of repositories belonging to the
+        organization [org]. *)
+
     (** The [Hook] module provides access to GitHub's
         {{:https://developer.github.com/v3/orgs/hooks/}organization
         webhooks API} which lets you manage an organization's

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -5,6 +5,8 @@
   (names 
    current_user
    current_user_orgs
+   organizations
+   organization_repos
     rwo
     get_token
     repo_info
@@ -18,6 +20,8 @@
   (deps
    current_user.exe
    current_user_orgs.exe
+   organizations.exe
+   organization_repos.exe
     rwo.exe
     get_token.exe
     repo_info.exe

--- a/lib_test/organization_repos.ml
+++ b/lib_test/organization_repos.ml
@@ -1,0 +1,17 @@
+open Github_t
+
+let token = Config.access_token
+
+let org = "mirage"
+
+let t = Github.(Monad.(run (
+    let orgs = Organization.repositories ~token ~org () in
+    Stream.to_list orgs >>= function
+    | [] -> Printf.eprintf "no repos for organisation\n"; exit 1
+    | x ->
+       List.iter (function repo ->
+                    Printf.eprintf "org %Ld: %s\n%!" repo.repository_id repo.repository_name) x;
+       return ())))
+;;
+
+Lwt_main.run t

--- a/lib_test/organizations.ml
+++ b/lib_test/organizations.ml
@@ -1,10 +1,9 @@
-open Lwt
 open Printf
 open Github_t
 
 let token = Config.access_token
 
-let org = "hammerlab"
+let org = "mirage"
 
 let t = Github.(Monad.(run (
   let get_teams = Organization.teams ~token:token ~org in


### PR DESCRIPTION
Added support for listing an organisation's repositories https://docs.github.com/en/rest/reference/repos#list-organization-repositories

I also added `organizations.exe` and `organization_repos.exe` to the lib_test dune so they can be built. I don't see where in CI these executables get run but I have run them locally successfully.