### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/ocaml-github/)
 
 This library provides an OCaml interface to the [GitHub
-APIv3](https://developer.github.com/v3/) (JSON). It is compatible with
+APIv3](https://docs.github.com/rest/) (JSON). It is compatible with
 [MirageOS](https://mirage.io) and also compiles to pure JavaScript via
 [js_of_ocaml](http://ocsigen.org/js_of_ocaml).
 
@@ -84,17 +84,17 @@ Some
   auth_token = "<token>";
   auth_app =
    {Github_t.app_name = "Real World OCaml";
-    app_url = "https://developer.github.com/v3/oauth_authorizations/"};
+    app_url = "https://docs.github.com/rest/reference/oauth-authorizations"};
   auth_url = "https://api.github.com/authorizations/236241";
   auth_id = 236241; auth_note = Some "rwo"; auth_note_url = None}
 ```
 
 ## Manipulate GitHub releases
 
-The [Releases](https://developer.github.com/v3/repos/releases/) API in
-GitHub cannot itself be synched via Git, so this command-line tool lets
-you specify a source user/repo and destination user/repo pair, and copies
-all the releases from one to the other.
+The [Releases](https://docs.github.com/rest/reference/repos#releases) API in
+GitHub cannot itself be synched via Git, so this command-line tool lets you
+specify a source user/repo and destination user/repo pair, and copies all the
+releases from one to the other.
 
 The `git-sync-releases` binary can copy all the releases from one
 repository to another for you.
@@ -113,13 +113,13 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
 
 ## API support coverage
 
-### [Media Types](https://developer.github.com/v3/media/)
+### [Media Types](https://docs.github.com/rest/overview/media-types)
 
 *Supported*: application/vnd.github.v3+json
 
 *Not yet supported*: Other media types
 
-### [OAuth](https://developer.github.com/v3/oauth/)
+### [OAuth](https://docs.github.com/developers/apps/authorizing-oauth-apps)
 *Supported*:
 
  * Web and non-Web flows with two-factor authentication
@@ -127,16 +127,16 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
 
 *Not yet supported*:
 
- * [Check](https://developer.github.com/v3/oauth_authorizations/#check-an-authorization) (see [#83](https://github.com/mirage/ocaml-github/issues/83))
- * [Reset](https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization) (see [#83](https://github.com/mirage/ocaml-github/issues/83))
+ * [Check](https://docs.github.com/rest/reference/oauth-authorizations) (see [#83](https://github.com/mirage/ocaml-github/issues/83))
+ * [Reset](https://docs.github.com/rest/reference/oauth-authorizations) (see [#83](https://github.com/mirage/ocaml-github/issues/83))
  * Fingerprint retrieval (see [#83](https://github.com/mirage/ocaml-github/issues/83))
  * get-or-create, update, revoke
  * fingerprint endpoints
 
-### [Activity](https://developer.github.com/v3/activity/)
+### [Activity](https://docs.github.com/rest/reference/activity)
 *Supported*:
 
- * All [Events](https://developer.github.com/v3/activity/events/) endpoints
+ * All [Events](https://docs.github.com/rest/reference/activity#events) endpoints
  * Event types: commit comment, create, delete, deployment, deployment status,
    download, follow, fork, fork apply, gist, gollum, issue comment,
    issues, member, page build, public, pull request, pull request review
@@ -145,12 +145,12 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
 *Not yet supported*:
 
  * Event types: membership
- * [Feeds](https://developer.github.com/v3/activity/feeds/)
- * [Notifications](https://developer.github.com/v3/activity/notifications/)
- * [Starring](https://developer.github.com/v3/activity/starring/)
- * [Watching](https://developer.github.com/v3/activity/watching/)
+ * [Feeds](https://docs.github.com/rest/reference/activity#feeds)
+ * [Notifications](https://docs.github.com/rest/reference/activity#notifications)
+ * [Starring](https://docs.github.com/rest/reference/activity#starring)
+ * [Watching](https://docs.github.com/rest/reference/activity#watching)
 
-### [Gists](https://developer.github.com/v3/gists/)
+### [Gists](https://docs.github.com/rest/reference/gists)
 *Supported*:
 
  * All endpoints
@@ -160,56 +160,56 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * Special media types
  * Truncation helpers
 
-### [Git Data](https://developer.github.com/v3/git/)
+### [Git Data](https://docs.github.com/rest/reference/git)
 
 *Not yet supported*: everything (see
  [#40](https://github.com/mirage/ocaml-github/issues/40))
 
-### [Issues](https://developer.github.com/v3/issues/)
+### [Issues](https://docs.github.com/rest/reference/issues)
 *Supported*:
 
  * All basic endpoints
  * Basic comments endpoints
- * [Milestones](https://developer.github.com/v3/issues/milestones/)
- * [Labels](https://developer.github.com/v3/issues/labels/)
- * [Repository issue comments](https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository)
- * [Get a single issue comment](https://developer.github.com/v3/issues/comments/#get-a-single-comment)
- * [Edit an issue comment](https://developer.github.com/v3/issues/comments/#edit-a-comment) (see [#87](https://github.com/mirage/ocaml-github/issues/87))
- * [Delete an issue comment](https://developer.github.com/v3/issues/comments/#delete-a-comment)
- * [Issue events](https://developer.github.com/v3/issues/events/)
- * [Timeline](https://developer.github.com/v3/issues/timeline/)
+ * [Milestones](https://docs.github.com/rest/reference/issues#milestones)
+ * [Labels](https://docs.github.com/rest/reference/issues#labels)
+ * [Repository issue comments](https://docs.github.com/rest/reference/issues#list-issue-comments-for-a-repository)
+ * [Get a single issue comment](https://docs.github.com/rest/reference/issues#get-an-issue-comment)
+ * [Edit an issue comment](https://docs.github.com/rest/reference/issues#update-an-issue-comment) (see [#87](https://github.com/mirage/ocaml-github/issues/87))
+ * [Delete an issue comment](https://docs.github.com/rest/reference/issues#delete-an-issue-comment)
+ * [Issue events](https://docs.github.com/rest/reference/issues#events)
+ * [Timeline](https://docs.github.com/rest/reference/issues#timeline)
 
 *Not yet supported*:
 
  * Custom media types
- * [Assignees](https://developer.github.com/v3/issues/assignees/)
+ * [Assignees](https://docs.github.com/rest/reference/issues#assignees)
 
-### [Miscellaneous](https://developer.github.com/v3/misc/)
+### Miscellaneous
 *Supported*:
 
- * [Rate limit](https://developer.github.com/v3/rate_limit/)
- * [Emojis](https://developer.github.com/v3/emojis)
+ * [Rate limit](https://docs.github.com/rest/reference/rate-limit)
+ * [Emojis](https://docs.github.com/rest/reference/emojis)
 
 *Not yet supported*:
 
- * [Gitignore](https://developer.github.com/v3/gitignore)
- * [Markdown](https://developer.github.com/v3/markdown)
- * [Meta](https://developer.github.com/v3/meta)
- * [Licenses](https://developer.github.com/v3/licenses)
+ * [Gitignore](https://docs.github.com/rest/reference/gitignore)
+ * [Markdown](https://docs.github.com/rest/reference/markdown)
+ * [Meta](https://docs.github.com/rest/reference/meta)
+ * [Licenses](https://docs.github.com/rest/reference/licenses)
 
-### [Organizations](https://developer.github.com/v3/orgs/)
+### [Organizations](https://docs.github.com/rest/reference/orgs)
 *Supported*:
 
- * [List teams](https://developer.github.com/v3/orgs/teams/#list-teams)
- * [Get team](https://developer.github.com/v3/orgs/teams/#get-team)
- * [List team repos](https://developer.github.com/v3/orgs/teams/#list-team-repos)
- * [List your organizations](https://developer.github.com/v3/orgs/#list-your-organizations)
- * [List (public) user organizations](https://developer.github.com/v3/orgs/#list-user-organizations)
- * [Webhooks](https://developer.github.com/v3/orgs/hooks/)
+ * [List teams](https://docs.github.com/rest/reference/teams#list-teams)
+ * [Get team](https://docs.github.com/rest/reference/teams#get-a-team-by-name)
+ * [List team repos](https://docs.github.com/rest/reference/teams#list-team-repositories)
+ * [List your organizations](https://docs.github.com/rest/reference/orgs#list-organizations-for-the-authenticated-user)
+ * [List (public) user organizations](https://docs.github.com/rest/reference/orgs#list-organizations-for-a-user)
+ * [Webhooks](https://docs.github.com/rest/reference/orgs#webhooks)
 
 *Not yet supported*: everything else
 
-### [Pull Requests](https://developer.github.com/v3/pulls/)
+### [Pull Requests](https://docs.github.com/rest/reference/pulls)
 *Supported*:
 
  * All endpoints
@@ -219,103 +219,103 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * Link relations
  * Custom media types
 
-### [Repositories](https://developer.github.com/v3/repos/)
+### [Repositories](https://docs.github.com/rest/reference/repos)
 *Supported*:
 
- * [Create](https://developer.github.com/v3/repos/#create)
+ * [Create](https://docs.github.com/rest/reference/repos#create-a-repository-for-the-authenticated-user)
  * [List user
-   repositories](https://developer.github.com/v3/repos/#list-user-repositories)
- * [Get](https://developer.github.com/v3/repos/#get)
- * [Delete repository](https://developer.github.com/v3/repos/#delete-a-repository)
- * [List tags](https://developer.github.com/v3/repos/#list-tags)
- * [List branches](https://developer.github.com/v3/repos/#list-branches)
+   repositories](https://docs.github.com/rest/reference/repos#list-repositories-for-a-user)
+ * [Get](https://docs.github.com/rest/reference/repos#get-a-repository)
+ * [Delete repository](https://docs.github.com/rest/reference/repos#delete-a-repository)
+ * [List tags](https://docs.github.com/rest/reference/repos#list-repository-tags)
+ * [List branches](https://docs.github.com/rest/reference/repos#list-branches)
  * [Get a single
-   commit](https://developer.github.com/v3/repos/commits/#get-a-single-commit)
- * [Deploy keys](https://developer.github.com/v3/repos/keys/)
- * [Forks](https://developer.github.com/v3/repos/forks/)
- * Most [Releases](https://developer.github.com/v3/repos/releases/) endpoints
+   commit](https://docs.github.com/rest/reference/repos#get-a-commit)
+ * [Deploy keys](https://docs.github.com/rest/reference/repos#deploy-keys)
+ * [Forks](https://docs.github.com/rest/reference/repos#forks)
+ * Most [Releases](https://docs.github.com/rest/reference/repos#releases) endpoints
  * [Create a
-   status](https://developer.github.com/v3/repos/statuses/#create-a-status)
+   status](https://docs.github.com/rest/reference/repos#create-a-commit-status)
  * [List statuses for a specific
-   ref](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref)
+   ref](https://docs.github.com/rest/reference/repos#list-commit-statuses-for-a-reference)
  * [Get the combined status for a specific
-   ref](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref)
- * [List contributors](https://developer.github.com/v3/repos/#list-contributors)
- * Most [Webhooks](https://developer.github.com/v3/repos/hooks/) endpoints
- * [Get contributors list with additions, deletions, and commit counts](https://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts)
- * [Collaborators](https://developer.github.com/v3/repos/collaborators/)
+   ref](https://docs.github.com/rest/reference/repos#get-the-combined-status-for-a-specific-reference)
+ * [List contributors](https://docs.github.com/rest/reference/repos#list-repository-contributors)
+ * Most [Webhooks](https://docs.github.com/rest/reference/repos#webhooks) endpoints
+ * [Get contributors list with additions, deletions, and commit counts](https://docs.github.com/rest/reference/repos#get-all-contributor-commit-activity)
+ * [Collaborators](https://docs.github.com/rest/reference/repos#collaborators)
  * [List organization
-   repositories](https://developer.github.com/v3/repos/#list-organization-repositories)
+   repositories](https://docs.github.com/rest/reference/repos#list-organization-repositories)
  * [Get the last year of commit activity
-   data](https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
- * [Get the number of additions and deletions per week](https://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
- * [Get the weekly commit count for the repository owner and everyone else](https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repository-owner-and-everyone-else) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
- * [Get the number of commits per hour in each day](https://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
+   data](https://docs.github.com/rest/reference/repos#get-the-last-year-of-commit-activity) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
+ * [Get the number of additions and deletions per week](https://docs.github.com/rest/reference/repos#get-the-weekly-commit-activity) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
+ * [Get the weekly commit count for the repository owner and everyone else](https://docs.github.com/rest/reference/repos#get-the-weekly-commit-count) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
+ * [Get the number of commits per hour in each day](https://docs.github.com/rest/reference/repos#get-the-hourly-commit-count-for-each-day) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
 
 *Not yet supported*:
 
  * [List your
-   repositories](https://developer.github.com/v3/repos/#list-your-repositories)
+   repositories](https://docs.github.com/rest/reference/repos#list-repositories-for-the-authenticated-user)
  * [List all public
-   repositories](https://developer.github.com/v3/repos/#list-all-public-repositories)
- * [Edit](https://developer.github.com/v3/repos/#edit)
+   repositories](https://docs.github.com/rest/reference/repos#list-public-repositories)
+ * [Edit](https://docs.github.com/rest/reference/repos#update-a-repository)
  * [List
-   languages](https://developer.github.com/v3/repos/#list-languages)
- * [List teams](https://developer.github.com/v3/repos/#list-teams)
- * [Get branch](https://developer.github.com/v3/repos/#get-branch)
- * [Commit comments](https://developer.github.com/v3/repos/comments/)
+   languages](https://docs.github.com/rest/reference/repos#list-repository-languages)
+ * [List teams](https://docs.github.com/rest/reference/repos#list-repository-teams)
+ * [Get branch](https://docs.github.com/rest/reference/repos#get-a-branch)
+ * [Commit comments](https://docs.github.com/rest/reference/repos#comments)
  * [List
-   commits](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository)
+   commits](https://docs.github.com/rest/reference/repos#list-commits)
  * [Compare two
-   commits](https://developer.github.com/v3/repos/commits/#compare-two-commits)
- * [Contents](https://developer.github.com/v3/repos/contents/)
- * [Deployments](https://developer.github.com/v3/repos/deployments/)
- * [Merging](https://developer.github.com/v3/repos/merging/)
- * [Pages](https://developer.github.com/v3/repos/pages/)
+   commits](https://docs.github.com/rest/reference/repos#compare-two-commits)
+ * [Contents](https://docs.github.com/rest/reference/repos#contents)
+ * [Deployments](https://docs.github.com/rest/reference/repos#deployments)
+ * [Merging](https://docs.github.com/rest/reference/repos#merging)
+ * [Pages](https://docs.github.com/rest/reference/repos#pages)
  * [Get the latest
-   release](https://developer.github.com/v3/repos/releases/#get-the-latest-release)
- * [Get a release by tag name](https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name)
+   release](https://docs.github.com/rest/reference/repos#get-the-latest-release)
+ * [Get a release by tag name](https://docs.github.com/rest/reference/repos#get-a-release-by-tag-name)
  * [List assets for a
-   release](https://developer.github.com/v3/repos/releases/#list-assets-for-a-release)
+   release](https://docs.github.com/rest/reference/repos#list-release-assets)
  * [Get a single release
-   asset](https://developer.github.com/v3/repos/releases/#get-a-single-release-asset)
+   asset](https://docs.github.com/rest/reference/repos#get-a-release-asset)
  * [Edit a release
-   asset](https://developer.github.com/v3/repos/releases/#edit-a-release-asset)
+   asset](https://docs.github.com/rest/reference/repos#update-a-release-asset)
  * [Delete a release
-   asset](https://developer.github.com/v3/repos/releases/#delete-a-release-asset)
+   asset](https://docs.github.com/rest/reference/repos#delete-a-release-asset)
  * [Ping a
-   hook](https://developer.github.com/v3/repos/hooks/#ping-a-hook)
- * [PubSubHubbub](https://developer.github.com/v3/repos/hooks/#pubsubhubbub)
+   hook](https://docs.github.com/rest/reference/repos#ping-a-repository-webhook)
+ * [PubSubHubbub](https://docs.github.com/rest/reference/repos#pubsubhubbub)
  * [Receiving Webhooks
-   helpers](https://developer.github.com/v3/repos/hooks/#receiving-webhooks)
+   helpers](https://docs.github.com/rest/reference/repos#receiving-webhooks)
 
-### [Search](https://developer.github.com/v3/search/)
+### [Search](https://docs.github.com/rest/reference/search)
 *Supported*:
 
  * [Search
-   repositories](https://developer.github.com/v3/search/#search-repositories)
+   repositories](https://docs.github.com/rest/reference/search#search-repositories)
 
 *Not yet supported*:
 
- * [Search code](https://developer.github.com/v3/search/#search-code)
- * [Search issues](https://developer.github.com/v3/search/#search-issues)
- * [Search users](https://developer.github.com/v3/search/#search-users)
+ * [Search code](https://docs.github.com/rest/reference/search#search-code)
+ * [Search issues](https://docs.github.com/rest/reference/search#search-issues-and-pull-requests)
+ * [Search users](https://docs.github.com/rest/reference/search#search-users)
  * [Text match media
-    type](https://developer.github.com/v3/search/#text-match-metadata)
+    type](https://docs.github.com/rest/reference/search#text-match-metadata)
 
-### [Users](https://developer.github.com/v3/users/)
+### [Users](https://docs.github.com/rest/reference/users)
 *Supported*:
 
  * [Get a single
-   user](https://developer.github.com/v3/users/#get-a-single-user)
+   user](https://docs.github.com/rest/reference/users#get-a-user)
  * [Get the authenticated
-   user](https://developer.github.com/v3/users/#get-the-authenticated-user)
+   user](https://docs.github.com/rest/reference/users#get-the-authenticated-user)
 
 *Not yet supported*:
 
  * [Update the authenticated
-   user](https://developer.github.com/v3/users/#update-the-authenticated-user)
- * [Get all users](https://developer.github.com/v3/users/#get-all-users)
+   user](https://docs.github.com/rest/reference/users#update-the-authenticated-user)
+ * [Get all users](https://docs.github.com/rest/reference/users#list-users)
 
-### [Enterprise](https://developer.github.com/v3/enterprise/)
+### [Enterprise](https://docs.github.com/rest/reference/enterprise-admin)
 *Not yet supported*: everything

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
   stringext)
  (synopsis "GitHub APIv3 OCaml library")
  (description "This library provides an OCaml interface to the
-[GitHub APIv3](https://developer.github.com/v3/) (JSON).
+[GitHub APIv3](https://docs.github.com/rest/) (JSON).
 
 It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
 JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."))
@@ -42,7 +42,7 @@ JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."))
   (cohttp-lwt-jsoo (>= 0.99.0))
   (js_of_ocaml-lwt (>= 3.4.0)))
  (synopsis "GitHub APIv3 JavaScript library")
- (description "This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+ (description "This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
 (JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."))
 
 (package
@@ -58,5 +58,5 @@ JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."))
   (cmdliner (>= 0.9.8))
   base-unix)
  (synopsis "GitHub APIv3 Unix library")
- (description "This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+ (description "This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
 (JSON).  This package installs the Unix (Lwt) version."))

--- a/github-jsoo.opam
+++ b/github-jsoo.opam
@@ -25,7 +25,7 @@ license: "MIT"
 dev-repo: "git+https://github.com/mirage/ocaml-github.git"
 synopsis: "GitHub APIv3 JavaScript library"
 description: """
-This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/v3/)
 (JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/github-unix.opam
+++ b/github-unix.opam
@@ -25,7 +25,7 @@ license: "MIT"
 dev-repo: "git+https://github.com/mirage/ocaml-github.git"
 synopsis: "GitHub APIv3 Unix library"
 description: """
-This library provides an OCaml interface to the [GitHub APIv3](https://developer.github.com/v3/)
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/v3/)
 (JSON).  This package installs the Unix (Lwt) version."""
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/github.opam
+++ b/github.opam
@@ -26,7 +26,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-github.git"
 synopsis: "GitHub APIv3 OCaml library"
 description: """
 This library provides an OCaml interface to the
-[GitHub APIv3](https://developer.github.com/v3/) (JSON).
+[GitHub APIv3](https://docs.github.com/v3/) (JSON).
 
 It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
 JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -2097,7 +2097,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
   module Gist = struct
     open Lwt
 
-    (* List gists https://developer.github.com/v3/gists/#list-gists
+    (* List gists https://docs.github.com/v3/gists/#list-gists
      * Parameters
      *  since : string   A timestamp in ISO 8601 format:
      *                   YYYY-MM-DDTHH:MM:SSZ. Only gists updated at
@@ -2136,13 +2136,13 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       let uri = uri_param_since uri since in
       API.get_stream ?token ~uri (fun b -> return (gists_of_string b))
 
-    (* Get a single gist https://developer.github.com/v3/gists/#get-a-single-gist
+    (* Get a single gist https://docs.github.com/rest/reference/gists#get-a-gist
      * GET /gists/:id  *)
     let get ?token ~id () =
       let uri = URI.gist ~id in
       API.get ?token ~uri (fun b -> return (gist_of_string b))
 
-    (* Create a gist https://developer.github.com/v3/gists/#create-a-gist
+    (* Create a gist https://docs.github.com/rest/reference/gists#create-a-gist
      * POST /gists
      * input
      *  files       hash      Required. Files that make up this gist.
@@ -2153,7 +2153,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       let body = string_of_new_gist gist in
       API.post ~body ?token ~uri ~expected_code:`Created (fun b -> return (gist_of_string b))
 
-    (* Edit a gist https://developer.github.com/v3/gists/#edit-a-gist
+    (* Edit a gist https://docs.github.com/rest/reference/gists#update-a-gist
      * PATCH /gists/:id
      * input
      *  description string  A description of the gist.
@@ -2165,42 +2165,42 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       let body = string_of_update_gist gist in
       API.patch ~body ?token ~uri ~expected_code:`OK (fun b -> return (gist_of_string b))
 
-    (* List gist commits https://developer.github.com/v3/gists/#list-gist-commits
+    (* List gist commits https://docs.github.com/rest/reference/gists#list-gist-commits
      * GET /gists/:id/commits *)
     let commits ?token ~id () =
       let uri = URI.gist_commits ~id in
       API.get_stream ?token ~uri (fun b -> return (gist_commits_of_string b))
 
-    (* Star a gist https://developer.github.com/v3/gists/#star-a-gist
+    (* Star a gist https://docs.github.com/rest/reference/gists#star-a-gist
      * PUT /gists/:id/star *)
     let star ?token ~id () =
       let uri = URI.gist_star ~id in
       API.put ?token ~uri ~expected_code:`No_content (fun _b -> return ())
 
-    (* Unstar a gist https://developer.github.com/v3/gists/#unstar-a-gist
+    (* Unstar a gist https://docs.github.com/rest/reference/gists#unstar-a-gist
      * DELETE /gists/:id/star *)
     let unstar ?token ~id () =
       let uri = URI.gist_star ~id in
       API.delete ?token ~uri ~expected_code:`No_content (fun _b -> return ())
 
-    (* Check if a gist is starred https://developer.github.com/v3/gists/#check-if-a-gist-is-starred
+    (* Check if a gist is starred https://docs.github.com/rest/reference/gists#check-if-a-gist-is-starred
      * GET /gists/:id/star
      * Response if gist is starred : 204 No Content
      * Response if gist is not starred : 404 Not Found *)
 
-    (* Fork a gist https://developer.github.com/v3/gists/#fork-a-gist
+    (* Fork a gist https://docs.github.com/rest/reference/gists#fork-a-gist
      * POST /gists/:id/forks *)
     let fork ?token ~id () =
       let uri = URI.gist_forks ~id in
       API.post ?token ~uri ~expected_code:`Created (fun b -> return (gist_of_string b))
 
-    (* List gist forks https://developer.github.com/v3/gists/#list-gist-forks
+    (* List gist forks https://docs.github.com/rest/reference/gists#list-gist-forks
      * GET /gists/:id/forks *)
     let forks ?token ~id () =
       let uri = URI.gist_forks ~id in
       API.get_stream ?token ~uri (fun b -> return (gist_forks_of_string b))
 
-    (* Delete a gist https://developer.github.com/v3/gists/#delete-a-gist
+    (* Delete a gist https://docs.github.com/rest/reference/gists#delete-a-gist
      * DELETE /gists/:id *)
     let delete ?token ~id () =
       let uri = URI.gist ~id in

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -17,7 +17,7 @@
  *)
 
 (**
-   {3 {{:https://developer.github.com/v3/}GitHub APIv3} client library}
+   {3 {{:https://docs.github.com/rest}GitHub APIv3} client library}
 
    This library offers thin but natural bindings to GitHub's developer API.
 *)
@@ -201,9 +201,9 @@ module type Github = sig
 
   type rate = Core | Search (**)
   (** [rate] is a type used to indicate which
-      {{:https://developer.github.com/v3/#rate-limiting}rate-limiting
-      regime} is to be used for query quota accounting. [rate] is used
-      by the function in {!API}. *)
+      {{:https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting}rate-limiting
+      regime} is to be used for query quota accounting. [rate] is used by the
+      function in {!API}. *)
 
   type 'a authorization =
     | Result of 'a
@@ -227,7 +227,7 @@ module type Github = sig
       when the environment variable [GITHUB_DEBUG] is set to 1. *)
 
   (** The [Scope] module abstracts GitHub's
-      {{:https://developer.github.com/v3/oauth/#scopes}authorization
+      {{:https://docs.github.com/developers/apps/scopes-for-oauth-apps#available-scopes}authorization
       scopes}. *)
   module Scope : sig
     val to_string : Github_t.scope -> string
@@ -258,15 +258,15 @@ module type Github = sig
 
   (** The [Token] module manipulates authorization tokens. GitHub has
       two types of tokens:
-      {{:https://developer.github.com/v3/oauth/}OAuth application
+      {{:https://docs.github.com/developers/apps/authorizing-oauth-apps}OAuth application
       tokens} and
-      {{:https://help.github.com/articles/creating-an-access-token-for-command-line-use/}"personal
+      {{:https://docs.github.com/github/authenticating-to-github/creating-a-personal-access-token}"personal
       tokens"}.
 
       Note: the OAuth Authorizations API has been deprecated by GitHub.
 
-      @see <https://developer.github.com/v3/oauth_authorizations/> OAuth Authorizations API
-      @see <https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#deprecating-and-adding-endpoints-for-the-oauth-authorizations-and-oauth-applications-apis>
+      @see <https://docs.github.com/rest/reference/oauth-authorizations> OAuth Authorizations API
+      @see <https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#deprecating-and-adding-endpoints-for-the-oauth-authorizations-and-oauth-applications>
       for the OAuth Authorizations deprecation.
   *)
   module Token : sig
@@ -278,7 +278,7 @@ module type Github = sig
       unit -> t option Lwt.t
     (** [of_code ~client_id ~client_secret ~code ()] is the {!t}
         granted by a [code] from an
-        {{:https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site}OAuth
+        {{:https://docs.github.com/developers/apps/authorizing-oauth-apps#web-application-flow}OAuth
         web flow redirect}. *)
 
     val create : ?scopes:Github_t.scope list -> ?note:string ->
@@ -328,7 +328,7 @@ module type Github = sig
       entirety of the GitHub API and these bindings. In particular,
       this module contains:
 
-      - {{:https://developer.github.com/v3/#http-verbs}generic accessor functions},
+      - {{:https://docs.github.com/rest/overview/resources-in-the-rest-api#http-verbs}generic accessor functions},
         not normally used directly, but useful if you wish to invoke
         API endpoints not yet bound.
       - handler constructors to help with using the generic accessors
@@ -378,7 +378,7 @@ module type Github = sig
     (** [get_stream uri stream_p] is the {!Stream.t} encapsulating
         lazy [stream_p]-parsed responses to GitHub API HTTP GET
         requests to [uri] and
-        {{:https://developer.github.com/v3/#pagination}its
+        {{:https://docs.github.com/rest/overview/resources-in-the-rest-api#pagination}its
         successors}. For an explanation of the other
         parameters, see {!get}. *)
 
@@ -481,7 +481,7 @@ module type Github = sig
       client_id:string -> state:string -> unit -> Uri.t
     (** [authorize ?scopes ?redirect_uri ~client_id ~state ()] is the
         URL to
-        {{:https://developer.github.com/v3/oauth/#redirect-users-to-request-github-access}redirect
+        {{:https://docs.github.com/developers/apps/authorizing-oauth-apps#redirect-urls}redirect
         users} to in an OAuth2 flow to create an authorization
         token. [?redirect_url] is the URL in your Web application
         where users will be sent after authorization. If omitted, it
@@ -632,7 +632,7 @@ module type Github = sig
   end
 
   (** The [Organization] module exposes the functionality of the
-      GitHub {{:https://developer.github.com/v3/orgs/}organization
+      GitHub {{:https://docs.github.com/rest/reference/orgs}organization
       API}. *)
   module Organization : sig
     val teams :
@@ -665,7 +665,7 @@ module type Github = sig
         organization [org]. *)
 
     (** The [Hook] module provides access to GitHub's
-        {{:https://developer.github.com/v3/orgs/hooks/}organization
+        {{:https://docs.github.com/rest/reference/orgs#webhooks}organization
         webhooks API} which lets you manage an organization's
         remote notification hooks. *)
     module Hook : sig
@@ -722,7 +722,7 @@ module type Github = sig
   end
 
   (** The [Team] module contains functionality relating to GitHub's
-      {{:https://developer.github.com/v3/orgs/teams/}team API}. *)
+      {{:https://docs.github.com/rest/reference/teams}team API}. *)
   module Team : sig
     val info :
       ?token:Token.t ->
@@ -739,7 +739,7 @@ module type Github = sig
   end
 
   (** The [Event] module exposes GitHub's
-      {{:https://developer.github.com/v3/activity/events/}event API}
+      {{:https://docs.github.com/rest/reference/activity#events}event API}
       functionality. *)
   module Event : sig
     val for_repo :
@@ -802,7 +802,7 @@ module type Github = sig
   end
 
   (** The [Repo] module offers the functionality of GitHub's
-      {{:https://developer.github.com/v3/repos/}repository API}. *)
+      {{:https://docs.github.com/rest/reference/repos}repository API}. *)
   module Repo : sig
     val create :
       ?token:Token.t ->
@@ -868,7 +868,7 @@ module type Github = sig
       ?ty:string -> user:string -> repo:string ->
       unit -> Github_t.git_ref Stream.t
     (** [refs ?ty ~user ~repo ()] is a stream of all
-        {{:https://developer.github.com/v3/git/refs/}git references}
+        {{:https://docs.github.com/rest/reference/git#references}git references}
         with prefix [?ty] for repo [user]/[repo]. *)
 
     val get_ref :
@@ -877,7 +877,7 @@ module type Github = sig
       name:string ->
       unit -> Github_t.git_ref Response.t Monad.t
     (** [get_ref ~user ~repo ~name] is the
-        {{:https://developer.github.com/v3/git/refs/}git reference}
+        {{:https://docs.github.com/rest/reference/git#references}git reference}
         with name [name] for repo [user]/[repo]. *)
 
     val get_commit :
@@ -901,7 +901,7 @@ module type Github = sig
         been deleted. *)
 
     (** The [Hook] module provides access to GitHub's
-        {{:https://developer.github.com/v3/repos/hooks/}webhooks API}
+        {{:https://docs.github.com/rest/reference/repos#webhooks}webhooks API}
         which lets you manage a repository's post-receive hooks. *)
     module Hook : sig
       val for_repo :
@@ -964,7 +964,7 @@ module type Github = sig
   end
 
   (** The [Stats] module exposes the functionality of GitHub's
-      {{:https://developer.github.com/v3/repos/statistics/}repository
+      {{:https://docs.github.com/rest/reference/repos#statistics}repository
       statistics API} which provides historical data regarding the
       aggregate behavior of a repository. *)
   module Stats : sig
@@ -1018,7 +1018,7 @@ module type Github = sig
   end
 
   (** The [Status] module provides the functionality of GitHub's
-      {{:https://developer.github.com/v3/repos/statuses/}status API}. *)
+      {{:https://docs.github.com/rest/reference/repos#statuses}status API}. *)
   module Status : sig
     val for_ref :
       ?token:Token.t ->
@@ -1050,7 +1050,7 @@ module type Github = sig
   end
 
   (** The [Pull] module contains functionality relating to GitHub's
-      {{:https://developer.github.com/v3/pulls/}pull request API}. *)
+      {{:https://docs.github.com/rest/reference/pulls}pull request API}. *)
   module Pull : sig
     val for_repo :
       ?token:Token.t ->
@@ -1128,7 +1128,7 @@ module type Github = sig
   end
 
   (** The [Issue] module gives users access to GitHub's
-      {{:https://developer.github.com/v3/issues/}issue API}. *)
+      {{:https://docs.github.com/rest/reference/issues}issue API}. *)
   module Issue: sig
     val for_repo :
       ?token:Token.t -> ?creator:string -> ?mentioned:string ->
@@ -1294,7 +1294,7 @@ module type Github = sig
   end
 
   (** The [Label] module exposes Github's
-      {{:https://developer.github.com/v3/issues/labels/}labels
+      {{:https://docs.github.com/rest/reference/issues#labels}labels
       API}. *)
   module Label : sig
     val for_repo :
@@ -1349,7 +1349,7 @@ module type Github = sig
   end
 
   (** The [Collaborator] module exposes Github's
-      {{:https://developer.github.com/v3/repos/collaborators/}collaborators
+      {{:https://docs.github.com/rest/reference/repos#collaborators}collaborators
       API}. *)
   module Collaborator : sig
     val for_repo :
@@ -1394,7 +1394,7 @@ module type Github = sig
   end
 
   (** The [Milestone] module exposes GitHub's
-      {{:https://developer.github.com/v3/issues/milestones/}milestone
+      {{:https://docs.github.com/rest/reference/issues#milestones}milestone
       API}. *)
   module Milestone : sig
     val for_repo:
@@ -1451,7 +1451,7 @@ module type Github = sig
   end
 
   (** The [Release] module provides access to GitHub's
-      {{:https://developer.github.com/v3/repos/releases/}release API}
+      {{:https://docs.github.com/rest/reference/repos#releases}release API}
       features. *)
   module Release : sig
     val for_repo:
@@ -1510,9 +1510,9 @@ module type Github = sig
 
   (** The [Deploy_key] module provides the means to manage
       per-repository
-      {{:https://developer.github.com/guides/managing-deploy-keys/#deploy-keys}deploy
+      {{:https://docs.github.com/developers/overview/managing-deploy-keys#deploy-keys}deploy
       keys}.
-      @see <https://developer.github.com/v3/repos/keys/> deploy key API docs
+      @see <https://docs.github.com/rest/reference/repos#deploy-keys> deploy key API docs
   *)
   module Deploy_key : sig
     val for_repo:
@@ -1544,7 +1544,7 @@ module type Github = sig
   end
 
   (** The [Gist] module provides access to the GitHub
-      {{:https://developer.github.com/v3/gists/}gist API}. *)
+      {{:https://docs.github.com/rest/reference/gists}gist API}. *)
   module Gist : sig
     val for_user :
       ?token:Token.t ->
@@ -1629,7 +1629,7 @@ module type Github = sig
   end
 
   (** The [Emoji] module exposes GitHub's
-      {{:https://developer.github.com/v3/emojis/}emoji API}. *)
+      {{:https://docs.github.com/rest/reference/emojis}emoji API}. *)
   module Emoji : sig
     val list : ?token:Token.t -> unit -> Github_t.emojis Response.t Monad.t
     (** [list ()] is the list of all available emojis for use on
@@ -1638,7 +1638,7 @@ module type Github = sig
   end
 
   (** The [Search] module exposes GitHub's
-      {{:https://developer.github.com/v3/search/}search interfaces}. *)
+      {{:https://docs.github.com/rest/reference/search}search interfaces}. *)
   module Search : sig
     val repos :
       ?token:Token.t ->


### PR DESCRIPTION
A new documentation website has been deployed by GitHub on `docs.github.com`, making the precedent one `developer.github.com` deprecated.
Every link from `developer.github.com` has been moved to `docs.github.com` (with anchor fixed for some link).