### PR TITLE
Fix authentification of effectful (POST/PATCH/PUT) requests.

### DIFF
--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -821,7 +821,8 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
 
     (* Add the correct mime-type header and the authentication token. *)
     let realize_headers
-        ?token ?(media_type="application/vnd.github.v3+json")
+        ~token
+        ?(media_type="application/vnd.github.v3+json")
         headers =
       let headers = C.Header.add_opt headers "accept" media_type in
       match token with
@@ -834,7 +835,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       fun state -> Lwt.return
         (state,
          (Monad.(request ?token ?params
-                   {meth; uri; headers=realize_headers ?token ?media_type headers; body=""})
+                   {meth; uri; headers=realize_headers ~token ?media_type headers; body=""})
             (request ~rate ~token
                ((code_handler ~expected_code fn)::fail_handlers))))
 
@@ -851,7 +852,7 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       fun state -> Lwt.return
         (state,
         (Monad.(request ?token ?params
-                  {meth; uri; headers=realize_headers headers; body })
+                  {meth; uri; headers=realize_headers ~token headers; body })
            (request ~rate ~token
               ((code_handler ~expected_code fn)::fail_handlers))))
 


### PR DESCRIPTION
Effectful requests did not pass the [token] to the [realize_header], leading the request to be sent unauthentified.

The issue was reported in multiple issues in `opam-publish`:
- ocaml-opam/opam-publish#97
- ocaml-opam/opam-publish#99
- ocaml-opam/opam-publish#104

Tested by using `lib_test/create_pull.ml` (with custom value), but also with some part of `opam-publish` sources (by generating a token, and by creating a custom PR) 