### PR TITLE
Adding more endpoints around releases and release assets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,13 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Get the number of commits per hour in each day](https://docs.github.com/rest/reference/repos#get-the-hourly-commit-count-for-each-day) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
  * [Get the latest
    release](https://docs.github.com/rest/reference/repos#get-the-latest-release)
+ * [List assets for a
+   release](https://docs.github.com/rest/reference/repos#list-release-assets)
  * [Get a release by tag name](https://docs.github.com/rest/reference/repos#get-a-release-by-tag-name)
+ * [Get a single release
+   asset](https://docs.github.com/rest/reference/repos#get-a-release-asset)
+ * [Delete a release
+   asset](https://docs.github.com/rest/reference/repos#delete-a-release-asset)
 
 *Not yet supported*:
 
@@ -275,14 +281,10 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Deployments](https://docs.github.com/rest/reference/repos#deployments)
  * [Merging](https://docs.github.com/rest/reference/repos#merging)
  * [Pages](https://docs.github.com/rest/reference/repos#pages)
- * [List assets for a
-   release](https://docs.github.com/rest/reference/repos#list-release-assets)
- * [Get a single release
-   asset](https://docs.github.com/rest/reference/repos#get-a-release-asset)
+ * [Get the latest
+   release](https://docs.github.com/rest/reference/repos#get-the-latest-release)
  * [Edit a release
    asset](https://docs.github.com/rest/reference/repos#update-a-release-asset)
- * [Delete a release
-   asset](https://docs.github.com/rest/reference/repos#delete-a-release-asset)
  * [Ping a
    hook](https://docs.github.com/rest/reference/repos#ping-a-repository-webhook)
  * [PubSubHubbub](https://docs.github.com/rest/reference/repos#pubsubhubbub)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Get the number of additions and deletions per week](https://docs.github.com/rest/reference/repos#get-the-weekly-commit-activity) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
  * [Get the weekly commit count for the repository owner and everyone else](https://docs.github.com/rest/reference/repos#get-the-weekly-commit-count) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
  * [Get the number of commits per hour in each day](https://docs.github.com/rest/reference/repos#get-the-hourly-commit-count-for-each-day) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
+ * [Get the latest
+   release](https://docs.github.com/rest/reference/repos#get-the-latest-release)
 
 *Not yet supported*:
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Get the number of commits per hour in each day](https://docs.github.com/rest/reference/repos#get-the-hourly-commit-count-for-each-day) (see [#86](https://github.com/mirage/ocaml-github/issues/86))
  * [Get the latest
    release](https://docs.github.com/rest/reference/repos#get-the-latest-release)
+ * [Get a release by tag name](https://docs.github.com/rest/reference/repos#get-a-release-by-tag-name)
 
 *Not yet supported*:
 
@@ -274,9 +275,6 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
  * [Deployments](https://docs.github.com/rest/reference/repos#deployments)
  * [Merging](https://docs.github.com/rest/reference/repos#merging)
  * [Pages](https://docs.github.com/rest/reference/repos#pages)
- * [Get the latest
-   release](https://docs.github.com/rest/reference/repos#get-the-latest-release)
- * [Get a release by tag name](https://docs.github.com/rest/reference/repos#get-a-release-by-tag-name)
  * [List assets for a
    release](https://docs.github.com/rest/reference/repos#list-release-assets)
  * [Get a single release

--- a/jar/upload_release.ml
+++ b/jar/upload_release.ml
@@ -23,7 +23,7 @@ let ask_github fn = Github.(Monad.run (fn ()))
 
 let upload_release token user repo tag content_type filename =
   let open Github_t in
-  ask_github (Github.Release.get_by_tag_name ~token ~user ~repo ~tag)
+  ask_github (Github.Release.get_by_tag_name ~token ~user ~repo ~tag) >|= Github.Response.value
   >>= fun r ->
   let id = r.release_id in
   print_endline (sprintf "uploading to release id %Ld" id);

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -355,6 +355,12 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
           "https://uploads.github.com/repos/%s/%s/releases/%Ld/assets"
           user repo id)
 
+    let get_asset ~user ~repo ~id =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/releases/assets/%Ld" api user repo id)
+
+    let delete_asset ~user ~repo ~id =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/releases/assets/%Ld" api user repo id)
+
     let get_release_assets ~user ~repo ~id =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/releases/%Ld/assets" api user repo id)
 
@@ -1591,14 +1597,14 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       let uri = URI.repo_release_latest ~user ~repo in
       API.get ?token ~uri (fun b -> return (release_of_string b))
 
-    let delete ?token ~user ~repo ~id () =
-      let uri = URI.repo_release ~user ~repo ~id in
-      API.delete ?token ~uri (fun _ -> return ())
-
     let create ?token ~user ~repo ~release () =
       let uri = URI.repo_releases ~user ~repo in
       let body = string_of_new_release release in
       API.post ?token ~body ~uri ~expected_code:`Created (fun b -> return (release_of_string b))
+
+    let delete ?token ~user ~repo ~id () =
+      let uri = URI.repo_release ~user ~repo ~id in
+      API.delete ?token ~uri (fun _ -> return ())
 
     let update ?token ~user ~repo ~release ~id () =
       let uri = URI.repo_release ~user ~repo ~id in
@@ -1612,11 +1618,13 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       API.post ?token ~params ~headers ~body ~uri ~expected_code:`Created
         (fun _b -> return ())
 
-    (* let delete_asset Delete a release asset
-       DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}
-     *)
+    let delete_asset ?token ~user ~repo ~id () =
+      let uri = URI.delete_asset ~user ~repo ~id in
+      API.delete ?token ~uri (fun _ -> return ())
 
-    (* let get_asset  GET '/repos/{owner}/{repo}/releases/assets/{asset_id}' *)
+    let get_asset ?token ~user ~repo ~id () =
+      let uri = URI.get_asset ~user ~repo ~id in
+      API.get ?token ~uri (fun b -> return (release_asset_of_string b))
 
     let list_assets ?token ~user ~repo ~id () =
       let uri = URI.get_release_assets ~user ~repo ~id in

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -345,6 +345,9 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
     let repo_release ~user ~repo ~id =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/releases/%Ld" api user repo id)
 
+    let repo_release_latest ~user ~repo=
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/releases/latest" api user repo)
+
     let upload_release_asset ~user ~repo ~id =
       Uri.of_string (
         Printf.sprintf
@@ -1591,6 +1594,10 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
         in
         let msg = {Github_t.message_message=msg; message_errors=[]} in
         with_error (Semantic (`Not_found,msg))
+
+    let get_latest ?token ~user ~repo () =
+      let uri = URI.repo_release_latest ~user ~repo in
+      API.get ?token ~uri (fun b -> return (release_of_string b))
 
     let delete ?token ~user ~repo ~id () =
       let uri = URI.repo_release ~user ~repo ~id in

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -355,6 +355,9 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
           "https://uploads.github.com/repos/%s/%s/releases/%Ld/assets"
           user repo id)
 
+    let get_release_assets ~user ~repo ~id =
+      Uri.of_string (Printf.sprintf "%s/repos/%s/%s/releases/%Ld/assets" api user repo id)
+
     let repo_deploy_keys ~user ~repo =
       Uri.of_string (Printf.sprintf "%s/repos/%s/%s/keys" api user repo)
 
@@ -1608,6 +1611,16 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
       let uri = URI.upload_release_asset ~user ~repo ~id in
       API.post ?token ~params ~headers ~body ~uri ~expected_code:`Created
         (fun _b -> return ())
+
+    (* let delete_asset Delete a release asset
+       DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}
+     *)
+
+    (* let get_asset  GET '/repos/{owner}/{repo}/releases/assets/{asset_id}' *)
+
+    let list_assets ?token ~user ~repo ~id () =
+      let uri = URI.get_release_assets ~user ~repo ~id in
+      API.get ?token ~uri (fun b -> return (release_assets_of_string b))
   end
 
   module Deploy_key = struct

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -1479,6 +1479,13 @@ module type Github = sig
     (** [get_by_tag_name ~user ~repo ~tag ()] is the release in repo
         [user]/[repo] which is using git tag [tag]. *)
 
+    val get_latest:
+      ?token:Token.t ->
+      user:string -> repo:string ->
+      unit -> Github_t.release Response.t Monad.t
+    (** [get_latest ~user ~repo ()] is the latest published full release
+        in [user]/[repo]. *)
+
     val create :
       ?token:Token.t ->
       user:string -> repo:string ->

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -1508,6 +1508,11 @@ module type Github = sig
     (** [update ~user ~repo ~release ~id ()] is the updated release
         [id] in [user]/[repo] as described by [release]. *)
 
+    val list_assets:
+      ?token:Token.t ->
+      user:string -> repo:string -> id:int64 ->
+      unit -> Github_t.release_assets Response.t Monad.t
+
     val upload_asset :
       ?token:Token.t ->
       user:string -> repo:string ->

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -1512,6 +1512,22 @@ module type Github = sig
       ?token:Token.t ->
       user:string -> repo:string -> id:int64 ->
       unit -> Github_t.release_assets Response.t Monad.t
+    (** [list_assets ~user ~repo ~id ()] lists the assets in release
+        [id] in [user]/[repo]. *)
+
+    val get_asset:
+      ?token:Token.t ->
+      user:string -> repo:string -> id:int64 ->
+      unit -> Github_t.release_asset Response.t Monad.t
+    (** [get_asset ~user ~repo ~id ()] gets an asset from a release
+        [id] in [user]/[repo]. *)
+
+    val delete_asset:
+      ?token:Token.t ->
+      user:string -> repo:string -> id:int64 ->
+      unit -> unit Response.t Monad.t
+    (** [delete_asset ~user ~repo ~id ()] deletes an asset from a release
+        [id] in [user]/[repo]. *)
 
     val upload_asset :
       ?token:Token.t ->

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -1475,7 +1475,7 @@ module type Github = sig
     val get_by_tag_name:
       ?token:Token.t ->
       user:string -> repo:string -> tag:string ->
-      unit -> Github_t.release Monad.t
+      unit -> Github_t.release Response.t Monad.t
     (** [get_by_tag_name ~user ~repo ~tag ()] is the release in repo
         [user]/[repo] which is using git tag [tag]. *)
 

--- a/lib_data/github.atd
+++ b/lib_data/github.atd
@@ -1147,6 +1147,22 @@ type release_repo = {
 } <ocaml field_prefix="release_repo_">
 type release_repos = release_repo list
 
+type release_asset = {
+  url: string;
+  browser_download_url: string;
+  id: int <ocaml repr="int64">;
+  node_id: string;
+  name: string;
+  label: string;
+  state: string;
+  content_type: string;
+  size: int;
+  download_count: int;
+  ~created_at: string;
+  ~published_at: string;
+} <ocaml field_prefix="release_asset_">
+type release_assets = release_asset list
+
 type new_release = {
   tag_name: string;
   target_commitish: string;

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -10,6 +10,7 @@
     repo_info
     repo_stats
     contributors
+    releases
     user_type))
 
 (rule (copy config.ml.in config.ml))
@@ -25,5 +26,6 @@
     get_token.exe
     repo_info.exe
     repo_stats.exe
+    releases.exe
     contributors.exe
     user_type.exe))

--- a/lib_test/releases.ml
+++ b/lib_test/releases.ml
@@ -7,6 +7,13 @@ let name_of_release = Github_t.(function
   | { release_name=None      ;_} -> "NULL"
 )
 
+let latest_release m =
+  let open Github_t in
+  let name = name_of_release m in
+  eprintf "latest release %Ld: %s (%s)\n%!" m.release_id name m.release_created_at;
+  eprintf "--\n%!";
+  ()
+
 let print_releases m = Github.(Monad.(
   Stream.iter (fun m ->
       let open Github_t in
@@ -20,9 +27,10 @@ let print_releases m = Github.(Monad.(
 ))
 
 let t = Github.(Monad.(run (
-  return (Release.for_repo ~user:"avsm" ~repo:"ocaml-github" ())
-  >>= print_releases
-  >>= fun () ->
+  return (Release.for_repo ~user:"mirage" ~repo:"ocaml-github" ())
+  >>= print_releases >>= fun () ->
+  (Release.get_latest ~user:"mirage" ~repo:"ocaml-github" () >|= Response.value >|= latest_release)
+  >>= fun _ ->
   return (Release.for_repo ~user:"mirage" ~repo:"mirage" ())
   >>= print_releases
 )))


### PR DESCRIPTION
New endpoints for:
 * Get the latest release (https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-latest-release)
 * Get a release asset (https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-a-release-asset)
 * Delete a release asset (https://docs.github.com/rest/reference/repos#delete-a-release-asset)
 * Delete a release asset (https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#delete-a-release-asset)
 * List assets in a release (https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-release-assets)
 
Updated endpoint for:
 * Get release by tag name - previously this was getting all releases and finding the matching tag, there is a new direct API for doing this. (https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-a-release-by-tag-name)

I'm still working on adding other release based endpoints that we don't currently support so I'll update this as I go.