### PR TITLE
Tidy up dune files

### DIFF
--- a/gist/dune
+++ b/gist/dune
@@ -1,5 +1,5 @@
-(executables
+(executable
  (libraries cohttp-lwt-unix github_unix cmdliner passwd)
-  (public_names git-gist)
+  (public_name git-gist)
   (package github-unix)
-  (names gist))
+  (name gist))

--- a/gist/dune
+++ b/gist/dune
@@ -1,7 +1,5 @@
 (executables
  (libraries cohttp-lwt-unix github_unix cmdliner passwd)
-  (flags (:standard -principal -strict-sequence -g -safe-string
-                    -w "A-E-41-42-44-48"))
   (public_names git-gist)
   (package github-unix)
   (names gist))

--- a/jar/dune
+++ b/jar/dune
@@ -1,8 +1,6 @@
 (executables
  (libraries cohttp-lwt-unix github_unix cmdliner passwd)
   (package github-unix)
-  (flags (:standard -principal -strict-sequence -g -safe-string
-                    -w "A-E-41-42-44-48"))
   (public_names
    git-create-release
     git-sync-releases

--- a/js/dune
+++ b/js/dune
@@ -2,6 +2,4 @@
  (name github_jsoo)
   (public_name github-jsoo)
   (wrapped false)
-  (flags (:standard -principal -strict-sequence -g -safe-string
-                    -w "A-E-41-42-44-48"))
   (libraries github lwt js_of_ocaml-lwt cohttp-lwt cohttp-lwt-jsoo))

--- a/lib/dune
+++ b/lib/dune
@@ -14,9 +14,7 @@
   (public_name github)
   (wrapped false)
   (modules_without_implementation github_s)
-;; 27 and 32 should be enabled once
-;; https://github.com/janestreet/jbuilder/issues/61 is done
   (flags (:standard -principal -strict-sequence -g -safe-string
-                    -w "A-E-41-42-44-48" -w "-27-32"))
+                    -w "A-E-41-42-44-48" ))
   (modules github_s github_core github_json github_j github_t)
   (libraries cohttp uri cohttp-lwt yojson atdgen))

--- a/lib/dune
+++ b/lib/dune
@@ -14,7 +14,5 @@
   (public_name github)
   (wrapped false)
   (modules_without_implementation github_s)
-  (flags (:standard -principal -strict-sequence -g -safe-string
-                    -w "A-E-41-42-44-48" ))
   (modules github_s github_core github_json github_j github_t)
   (libraries cohttp uri cohttp-lwt yojson atdgen))

--- a/lib/dune
+++ b/lib/dune
@@ -10,9 +10,7 @@
 
 
 (library
- (name github)
   (public_name github)
   (wrapped false)
   (modules_without_implementation github_s)
-  (modules github_s github_core github_json github_j github_t)
   (libraries cohttp uri cohttp-lwt yojson atdgen))

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,7 +1,5 @@
 (executables
  (libraries cohttp-lwt-unix github_unix atdgen stringext cmdliner)
-  (flags (:standard -principal -strict-sequence -g -safe-string
-                    -w "A-E-41-42-44-48"))
   (names 
    current_user
    current_user_orgs

--- a/unix/dune
+++ b/unix/dune
@@ -2,5 +2,4 @@
  (name github_unix)
   (public_name github-unix)
   (wrapped false)
-  (modules github github_cookie_jar)
   (libraries lwt.unix cohttp-lwt-unix github bytes))

--- a/unix/dune
+++ b/unix/dune
@@ -2,7 +2,5 @@
  (name github_unix)
   (public_name github-unix)
   (wrapped false)
-  (flags (:standard -principal -strict-sequence -g -safe-string
-                    -w "A-E-41-42-44-48"))
   (modules github github_cookie_jar)
   (libraries lwt.unix cohttp-lwt-unix github bytes))


### PR DESCRIPTION
In the spirit of #246:

- Fix warnings 27 and 32

There was a link to an old dune issue but it seems that these were hiding some
problems.

- Use standard flags

To the best of my knowledge, it is best practice to let dune deal with flags.

- Use dune shortcuts

Small improvements by using shortcuts allowed by dune.
