### PR TITLE
Fix opam-dune-lint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,7 +56,8 @@ JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."))
   (cohttp-lwt-unix (and (>= 0.99.0) (< 3.0.0)))
   stringext
   (cmdliner (>= 0.9.8))
-  base-unix)
+  base-unix
+  lwt)
  (synopsis "GitHub APIv3 Unix library")
  (description "This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
 (JSON).  This package installs the Unix (Lwt) version."))

--- a/github-unix.opam
+++ b/github-unix.opam
@@ -36,4 +36,5 @@ depends: [
   "stringext"
   "cmdliner" {>= "0.9.8"}
   "base-unix"
+  "lwt"
 ]

--- a/js/dune
+++ b/js/dune
@@ -2,4 +2,4 @@
  (name github_jsoo)
   (public_name github-jsoo)
   (wrapped false)
-  (libraries github lwt js_of_ocaml-lwt cohttp-lwt cohttp-lwt-jsoo))
+  (libraries github js_of_ocaml-lwt cohttp-lwt-jsoo))


### PR DESCRIPTION
- Declare fewer dependencies in jsoo
- github-unix.opam: depend on lwt