### PR TITLE
label field missing in branch refs for ghost

### DIFF
--- a/lib_data/github.atd
+++ b/lib_data/github.atd
@@ -469,7 +469,7 @@ type repository_issue_search = {
 } <ocaml field_prefix="repository_issue_search_">
 
 type branch = {
-  label: string;
+  ~label <ocaml default="\"\"">: string;
   ref: string;
   sha: string;
   ?user: user option;


### PR DESCRIPTION
The label field can be `null`. For compatibility, I've defaulted that to `""` rather than changing the type.

Apparently `null` is used with the `ghost` user:

```ocaml
let open Github_t in
let pull =
  Lwt_main.run (Github.(Monad.(run (Pull.get ~user:"ocaml" ~repo:"ocaml" ~num:601 () >|= Response.value))))
in
  Printf.printf "PR %d: %s\n" pull.pull_number pull.pull_title
```