### PR TITLE
label field missing in branch refs for ghost

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## dev
+- label field missing in branch refs for ghost (@dra27 and @tmcgilchrist #256)
+
 ## 4.4.0 (2021-06-13)
 
 - Fixes to odoc warnings and cohttp dependencies (@Aaylor #244)

--- a/lib_data/github.atd
+++ b/lib_data/github.atd
@@ -469,7 +469,7 @@ type repository_issue_search = {
 } <ocaml field_prefix="repository_issue_search_">
 
 type branch = {
-  label: string;
+  label: string nullable;
   ref: string;
   sha: string;
   ?user: user option;


### PR DESCRIPTION
Standalone version of https://github.com/mirage/ocaml-github/pull/254 using string option.
