### PR TITLE
Conflict mis-matched `github` version in `github-data`

### DIFF
--- a/github-data.opam
+++ b/github-data.opam
@@ -28,9 +28,6 @@ depends: [
   "atdgen" {>= "2.0.0"}
   "odoc" {with-doc}
 ]
-conflicts: [
-  "github" {!= version}
-]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -46,3 +43,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+conflicts: [
+  "github" {!= version}
+]

--- a/github-data.opam
+++ b/github-data.opam
@@ -28,6 +28,9 @@ depends: [
   "atdgen" {>= "2.0.0"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "github" {!= version}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/github-data.opam.template
+++ b/github-data.opam.template
@@ -1,0 +1,3 @@
+conflicts: [
+  "github" {!= version}
+]


### PR DESCRIPTION
Older versions of github can be co-installed with github-data, but they are not co-linkable, which can result in confusing opam switches.

cf. https://github.com/ocaml/opam-repository/pull/20548