### PR TITLE
Updates the link to the ATD file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build/
 .merlin
 *.install
 lib_test/config.ml
+_opam/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ APIv3](https://docs.github.com/rest/) (JSON). It is compatible with
 [js_of_ocaml](http://ocsigen.org/js_of_ocaml).
 
 It is [not yet complete](#api-support-coverage) but
-[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib/github.atd)
+[lib/github.atd](https://github.com/mirage/ocaml-github/blob/master/lib_data/github.atd)
 contains the data types that have been bound so far.
 
 There are several tests and examples in


### PR DESCRIPTION
- Trivial fix to update a link in the readme.
- Also adds `_opam/` dir to .gitignore