### PR TITLE
Upgrade the API support to v2022-11-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ git upload-release mirage ocaml-uri v1.4.0 release.tar.gz
 
 ### [Media Types](https://docs.github.com/rest/overview/media-types)
 
-*Supported*: application/vnd.github.v3+json
+*Supported*: application/vnd.github+json
 
 *Not yet supported*: Other media types
 

--- a/github-data.opam
+++ b/github-data.opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "yojson" {>= "1.7.0"}
-  "atdgen" {>= "2.0.0"}
+  "atdgen" {>= "2.0.0" & < "2.16.0"}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -872,12 +872,13 @@ module Make(Env : Github_s.Env)(Time : Github_s.Time)(CL : Cohttp_lwt.S.Client)
     (* Add the correct mime-type header and the authentication token. *)
     let realize_headers
         ~token
-        ?(media_type="application/vnd.github.v3+json")
+        ?(media_type="application/vnd.github+json")
         headers =
       let headers = C.Header.add_opt headers "accept" media_type in
+      let headers = C.Header.add headers "X-GitHub-Api-Version" "2022-11-28" in
       match token with
       | None -> headers
-      | Some token -> C.Header.add headers "Authorization" ("token " ^ token)
+      | Some token -> C.Header.add headers "Authorization" ("Bearer " ^ token)
 
     let idempotent meth
         ?(rate=Core) ?media_type ?headers ?token ?params ~fail_handlers ~expected_code ~uri


### PR DESCRIPTION
Older versions are no longer supported. See https://docs.github.com/en/rest/about-the-rest-api/api-versions?apiVersion=2022-11-28